### PR TITLE
POC for plotting star field / catalog using bokeh

### DIFF
--- a/bokeh_stars.py
+++ b/bokeh_stars.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from jinja2 import Template
+
+from bokeh.io import vform
+from bokeh.models import CustomJS, ColumnDataSource, Slider, HoverTool
+from bokeh.plotting import figure # , output_file, show
+from bokeh.models.widgets.layouts import HBox
+from bokeh.embed import components
+from bokeh.resources import Resources
+
+n_stars = 50
+yags = np.random.uniform(-2400, 2400, size=n_stars)
+zags = np.random.uniform(-2400, 2400, size=n_stars)
+colors = ["navy"] * n_stars
+alphas = 0.5 * np.ones(n_stars)
+mags = np.random.uniform(6, 12, size=n_stars)
+sizes = 14 * np.ones(n_stars) - mags
+yag_zag_strs = ['{:.1f} {:.1f}'.format(yag, zag) for yag, zag in zip(yags, zags)]
+
+stars = ColumnDataSource(data=dict(yag=yags, zag=zags, color=colors,
+                                   alpha=alphas, mag=mags, size=sizes,
+                                   yag_zag_str=yag_zag_strs))
+# 
+
+hover = HoverTool(
+        tooltips=[
+            ("yag,zag", "@yag_zag_str"),
+            ("mag", "@mag"),
+        ]
+    )
+
+plot = figure(plot_width=400, plot_height=400, x_range=[2500, -2500], y_range=[-2500, 2500],
+              tools=[hover, 'box_zoom', 'pan', 'reset'])
+plot.yaxis.major_label_orientation = "vertical"
+
+plot.circle('yag', 'zag', color='color', size='size', alpha='alpha', source=stars)
+
+
+slider = Slider(start=6, end=12, value=12, step=.1, title="Mag limit")
+slider.callback = CustomJS(args=dict(source=stars), code="""
+        var data = source.get('data');
+        var f = cb_obj.get('value');
+        var alpha = 0.0;
+
+        // window.alert(Object.keys(data));
+        for (i = 0; i < data['size'].length; i++) {
+            if (data['mag'][i] > f) {
+                data['alpha'][i] = 0.0;
+            } else {
+                data['alpha'][i] = 0.5;
+            }
+        }
+
+        source.trigger('change');
+    """)
+
+
+layout = vform(HBox(slider), plot)
+
+resources = Resources('inline')  # Probably 'inline' for production
+script, div = components(plot, resources)
+
+with open('bokeh_stars_template.html', 'rb') as fh:
+    template = Template(fh.read())
+
+out = template.render(bokeh_js='\n'.join(resources.js_raw),
+                      bokeh_css='\n'.join(resources.css_raw),
+                      script=script, div=div)
+
+with open('bokeh_stars.html', 'wb') as fh:
+    fh.write(out)

--- a/bokeh_stars_template.html
+++ b/bokeh_stars_template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Star plot</title>
+        <style>
+        {{ bokeh_css }}
+        </style>
+        <script type="text/javascript">
+          {{ bokeh_js }}
+        </script>
+    </head>
+    <body>
+        <h1>Star plot</h1>
+        {{ div }}
+        {{ script }}
+    </body>
+</html>


### PR DESCRIPTION
@jeanconn - this is a proof of concept for using bokeh to generate interactive star catalog plots.  I think that we might generally want to have the default for starcheck / starhopper be the static matplotlib version for speed / compactness, but have links to an interactive version for when it's needed.  Using these simple javascript callbacks is nice and opens possibilities (like the mag filtering as shown, or highlighting candidates, or whatever).  This is making me like bokeh over mpld3 at this point.  (Well, probably can do similar with mpld3, but the question is whether that process is documented and accessible).

To go forward with this I would imagine refactoring the existing plotting routines to decouple the logic of assembling all the plot elements (like lines, annotations, and shapes) from the actual backend commands to put those into a plot.  But of course the bokeh version would end up getting a bit more complicated since because of the interactions.

I'm not planning on going further with this myself, this is a rainy day (or rainy week) project for you @jeanconn .
