### PR TITLE
More closely reproduce the starcheck fid symbol

### DIFF
--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -86,14 +86,13 @@ def _plot_catalog_items(ax, catalog):
     ax.scatter(fids['yang'], fids['zang'],
                facecolors='none',
                edgecolors='red',
-               linewidth=.5,
+               linewidth=1,
                marker='o',
                s=175)
     ax.scatter(fids['yang'], fids['zang'],
-               facecolors='none',
-               edgecolors='red',
+               facecolors='red',
                marker='+',
-               linewidth=.5,
+               linewidth=1,
                s=175)
 
 


### PR DESCRIPTION
Did any of the example plots ever show a fid light?  The line is too thin and there is no `+` to mark the spot.