### PR TITLE
Add flight EEPROM coefficients for pixel to angle conversion

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,6 +1,6 @@
 from .transform import *
 
-__version__ = '3.11'
+__version__ = '3.12'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -35,6 +35,18 @@ def test_pix_to_angle():
     np.testing.assert_allclose(pix_to_angle['zang'], pyzang, atol=TOLERANCE, rtol=0)
 
 
+def test_pix_to_angle_flight():
+    """
+    This is a minimal regression test.  For actual validation that the
+    values are correct see aca_track/predict_track.ipynb notebook.
+    """
+    yag, zag = chandra_aca.pixels_to_yagzag(100., 100., flight=True, t_aca=24.0)
+    assert np.allclose([yag, zag], [-467.7295724, 475.3100623])
+
+    yag, zag = chandra_aca.pixels_to_yagzag(100., 100., flight=True, t_aca=14.0)
+    assert np.allclose([yag, zag], [-467.8793858, 475.4463912])
+
+
 def test_angle_to_pix():
     angle_to_pix = ascii.read(os.path.join(dirname, 'data', 'angle_to_pix.txt'))
     print("testing {} yang/zang pairs match to {} pixels".format(

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from Quaternion import Quat
 
-# coefficients for converting from ACA angle to pixels
+# coefficients for converting from ACA angle to pixels (ground)
 ACA2PIX_coeff = np.array(
     [[6.08840495576943,         4.92618563916467],
      [0.000376181788609776,     0.200203020554239],
@@ -38,6 +38,35 @@ PIX2ACA_coeff = np.array(
      [-9.934587837231732e-16, -5.847450395792513e-13],
      [5.807475081470944e-13,   -1.842673748068349e-15]])
 
+# From /proj/sot/ska/analysis/aca_plate_scale/calib_prelaunch/eeprom_cal.txt
+# This is the full 20-coefficient solution that includes a
+# temperature dependence (but not a zero-order dependence).
+# The ground coefficients do not include the terms that have
+# temperature term.
+PIX2ACA_eeprom = np.array(
+    [[3.03464844e+01,  -2.46503906e+01],
+     [9.38110352e-03,   4.99642792e+00],
+     [-4.99528198e+00,  9.14611816e-03],
+     [0.00000000e+00,   0.00000000e+00],
+     [-1.14440918e-06,  2.53915787e-06],
+     [-1.19805336e-06,  3.72529030e-06],
+     [7.62343407e-06,  -1.25670433e-04],
+     [-5.62667847e-06,  1.03116035e-06],
+     [1.40523911e-04,  -1.25801563e-04],
+     [0.00000000e+00,   0.00000000e+00],
+     [4.65661287e-11,  -1.20745972e-07],
+     [1.17020682e-07,  -3.25962901e-10],
+     [1.06869265e-08,  -9.35979187e-09],
+     [-2.09547579e-10, -1.18976459e-07],
+     [-2.56113708e-09, -6.51925802e-09],
+     [-4.74276021e-07, -1.41877681e-06],
+     [1.18394382e-07,  -3.72529030e-10],
+     [-3.70200723e-09,  1.03842467e-08],
+     [5.06476499e-07,   4.46331687e-06]])
+
+# Convert from arcsec to radians
+PIX2ACA_eeprom = np.radians(PIX2ACA_eeprom / 3600)
+
 ACA_MAG0 = 10.32
 ACA_CNT_RATE_MAG0 = 5263.0
 
@@ -50,7 +79,7 @@ ODB_SI_ALIGN = np.array([[0.999999905689160, -0.000337419984089, -0.000273439987
                          [0.000273439987106, -0.000000046132060, 0.999999962615285]])
 
 
-def pixels_to_yagzag(row, col, allow_bad=False):
+def pixels_to_yagzag(row, col, allow_bad=False, flight=False, t_aca=20):
     """
     Convert ACA row/column positions to ACA y-angle, z-angle.
     It is expected that the row and column input arguments have the same length.
@@ -59,6 +88,8 @@ def pixels_to_yagzag(row, col, allow_bad=False):
     :param col: ACA pixel column (single value, list, or 1-d numpy array)
     :param allow_bad: boolean switch.  If true, method will not throw errors
                          if the row/col values are nominally off the ACA CCD.
+    :param flight: Use flight EEPROM coefficients instead of default ground values.
+    :param t_aca: ACA temperature (degC) for use with flight (default=20C)
     :rtype: (yang, zang) each vector of the same length as row/col
     """
     row = np.array(row)
@@ -67,7 +98,8 @@ def pixels_to_yagzag(row, col, allow_bad=False):
         (np.any(row > 511.5) or np.any(row < -512.5) or
          np.any(col > 511.5) or np.any(col < -512.5))):
         raise ValueError("Coordinate off CCD")
-    yrad, zrad = _poly_convert(row, col, PIX2ACA_coeff)
+    coeff = PIX2ACA_eeprom if flight else PIX2ACA_coeff
+    yrad, zrad = _poly_convert(row, col, coeff, t_aca)
     # convert to arcsecs from radians
     return 3600 * np.degrees(yrad), 3600 * np.degrees(zrad)
 
@@ -93,14 +125,30 @@ def yagzag_to_pixels(yang, zang, allow_bad=False):
     return row, col
 
 
-def _poly_convert(y, z, coeffs):
+def _poly_convert(y, z, coeffs, t_aca=None):
     if y.size != z.size:
         raise ValueError("Mismatched number of Y/Z coords")
-    yy = y * y
-    zz = z * z
-    poly = np.array([np.ones_like(y), z, y, zz, y * z, yy, zz * z, y * zz, yy * z, yy * y])
+
+    if len(coeffs) == 10:
+        # No temperature dependence
+        yy = y * y
+        zz = z * z
+        poly = np.array([np.ones_like(y), z, y, zz, y * z, yy, zz * z, y * zz, yy * z, yy * y])
+
+    elif len(coeffs) == 19:
+        # Full temperature dependent equation
+        c = z  # Use c and r corresponding to section 2.2.4 of ACA Equations document
+        r = y
+        ones = np.ones_like(c)
+        t = t_aca * ones
+        poly = np.array([ones, c, r, t, c*c, c*r, c*t, r*r, r*t, t*t, c*c*c, r*c*c,
+                         t*c*c, c*r*r, c*r*t, c*t*t, r*r*r, t*r*r, r*t*t])
+    else:
+        raise ValueError('Bad coefficients, length != 10 or 19')
+
     newy = np.sum(coeffs[:, 0] * poly.transpose(), axis=-1)
     newz = np.sum(coeffs[:, 1] * poly.transpose(), axis=-1)
+
     return newy, newz
 
 


### PR DESCRIPTION
This allows for exactly replicating the flight AOACYAN and AOACZAN values from telemetry without any need for arbitrary offsets.  It depends on the ACA housing temperature (AACH1T).