### PR TITLE
Add ad-hoc probability adjustment for larger acquisition search boxes

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -189,6 +189,40 @@ def prob_n_acq(star_probs):
     return n_acq_probs, np.cumsum(n_acq_probs)
 
 
+def get_halfwidth_mag_mult(halfwidth):
+    """
+    Return the piecewise-linear probability multiplier function for
+    a given search box halfwidth.
+
+    :param halfwidth: half width in arcsec
+    :returns: mag, mult (ndarrays)
+    """
+    # Special case of unit-valued multiplier for search box <= 120 arsec
+    if halfwidth <= 120:
+        mag = np.array([5.0, 17.0])
+        mult = np.array([1.0, 1.0])
+        return mag, mult
+
+    if halfwidth <= 160:
+        mult_10 = 0.8
+        mag_0p = 11.0
+    elif halfwidth <= 180:
+        mult_10 = 0.6
+        mag_0p = 10.5
+    elif halfwidth <= 240:
+        mult_10 = 0.4
+        mag_0p = 10.25
+    else:
+        mult_10 = 0.01
+        mag_0p = 10.01
+
+    # Define stepwise linear probability multiplier
+    mag = np.array([5.0, 8.5,  10.0,   mag_0p,  17.0])
+    mult = np.array([1.0, 1.0, mult_10,  0.01,   0.01])
+
+    return mag, mult
+
+
 def acq_success_prob(date=None, t_ccd=-19.0, mag=10.0, color=0.6, spoiler=False, halfwidth=120):
     """
     Return probability of acquisition success for given date, temperature and mag.
@@ -237,35 +271,17 @@ def acq_success_prob(date=None, t_ccd=-19.0, mag=10.0, color=0.6, spoiler=False,
     probs[colors == 0.7] *= p_0p7color
     probs[spoilers] *= p_spoiler
 
+    probs = probs.clip(1e-6, max_star_prob)
+
     # Ad-hoc correction for search box size > 120 arcsec.  This does a
     # multiplicative correction on the acquisition probability using a
     # piecewise linear curve.  It starts at 1.0 for mag < 8.5, then
     # down linearly to 10.0 mag to a a value depending on search box
     # size, and then down to 0.01.
     for ii in range(len(probs)):
-        if halfwidths[ii] <= 120:
-            continue
-        elif halfwidths[ii] <= 160:
-            mult_10 = 0.8
-            mag_0p = 11.0
-        elif halfwidths[ii] <= 180:
-            mult_10 = 0.6
-            mag_0p = 10.5
-        elif halfwidths[ii] <= 240:
-            mult_10 = 0.4
-            mag_0p = 10.25
-        else:
-            mult_10 = 0.01
-            mag_0p = 10.01
-
-        # Define stepwise linear probability multiplier
-        mag = np.array([5.0, 8.5,  10.0,   mag_0p,  17.0])
-        mult = np.array([1.0, 1.0, mult_10,  0.01,   0.01])
+        mag, mult = get_halfwidth_mag_mult(halfwidths[ii])
         p_mult = interpolate(mult, mag, [mags[ii]], method='linear')[0]
-
         probs[ii] *= p_mult
-
-    probs = probs.clip(1e-6, max_star_prob)
 
     # Return probabilities.  The [()] getitem at the end will flatten a
     # scalar array down to a pure scalar.

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -95,17 +95,18 @@ def test_mag_for_p_acq():
 
 
 def test_halfwidth_adjustment():
-    for mag, mults in ((6.0, [1.0, 1.0, 1.0, 1.0]),
-                       (8.5, [1.0, 1.0, 1.0, 1.0]),
-                       (9.25, [0.9, 0.8, 0.7, 0.505]),
-                       (10.0, [0.8, 0.6, 0.4, 0.01]),
-                       (11.0, [0.01, 0.01, 0.01, 0.01])):
+    for mag, mults in ((6.0, [1.0, 1.0, 1.0, 1.0, 1.0]),
+                       (8.5, [1.0, 1.0, 1.0, 1.0, 1.0]),
+                       (9.25, [0.9, 0.9, 0.8, 0.7, 0.505]),
+                       (10.0, [0.8, 0.8, 0.6, 0.4, 0.01]),
+                       (11.0, [0.01, 0.01, 0.01, 0.01, 0.01])):
         pacq = acq_success_prob(mag=mag, halfwidth=120)
+        p135 = acq_success_prob(mag=mag, halfwidth=135)
         p160 = acq_success_prob(mag=mag, halfwidth=160)
         p180 = acq_success_prob(mag=mag, halfwidth=180)
         p240 = acq_success_prob(mag=mag, halfwidth=240)
         p280 = acq_success_prob(mag=mag, halfwidth=280)
-        exp_mults = np.array([p160, p180, p240, p280]) / pacq
+        exp_mults = np.array([p135, p160, p180, p240, p280]) / pacq
         assert np.allclose(mults, exp_mults)
 
 

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -10,7 +10,7 @@ from Quaternion import Quat
 from Chandra.Time import DateTime
 
 import chandra_aca
-from chandra_aca.star_probs import t_ccd_warm_limit, mag_for_p_acq
+from chandra_aca.star_probs import t_ccd_warm_limit, mag_for_p_acq, acq_success_prob
 from chandra_aca import drift
 
 dirname = os.path.dirname(__file__)
@@ -92,6 +92,21 @@ def test_t_ccd_warm_limit():
 def test_mag_for_p_acq():
     mag = mag_for_p_acq(0.50, date='2015:001', t_ccd=-14.0)
     assert np.allclose(mag, 10.821, rtol=0, atol=0.01)
+
+
+def test_halfwidth_adjustment():
+    for mag, mults in ((6.0, [1.0, 1.0, 1.0, 1.0]),
+                       (8.5, [1.0, 1.0, 1.0, 1.0]),
+                       (9.25, [0.9, 0.8, 0.7, 0.505]),
+                       (10.0, [0.8, 0.6, 0.4, 0.01]),
+                       (11.0, [0.01, 0.01, 0.01, 0.01])):
+        pacq = acq_success_prob(mag=mag, halfwidth=120)
+        p160 = acq_success_prob(mag=mag, halfwidth=160)
+        p180 = acq_success_prob(mag=mag, halfwidth=180)
+        p240 = acq_success_prob(mag=mag, halfwidth=240)
+        p280 = acq_success_prob(mag=mag, halfwidth=280)
+        exp_mults = np.array([p160, p180, p240, p280]) / pacq
+        assert np.allclose(mults, exp_mults)
 
 
 def test_get_aimpoint():


### PR DESCRIPTION
Add ad-hoc probability adjustments for search boxes greater than 120 arcsecs.

To mitigate risk of safing action (BSH, NSM) due to observed attitude errors significantly larger than estimated attitude errors, test SAUSAGE has had had a new acquisition stage added (and one modified) to allow stage 1 stars to have up to 180 arcsec hw search boxes and stage 2 stars to have up to 160 arcsec hw search boxes.  This PR adds ad-hoc adjustments to acquisition probabilities for stars with bigger (> 120 arcsec) search boxes with the understanding that increasing the number of pixels in the box will also increase the chance that the star not be acquired due to hot pixel.   These new probabilities will be used in starcheck to review catalogs with these larger search boxes.