### PR TITLE
Add pix_zero_loc param for convention on pixel labeling

### DIFF
--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -58,6 +58,27 @@ def test_angle_to_pix():
     np.testing.assert_allclose(angle_to_pix['col'], pycol, atol=TOLERANCE, rtol=0)
 
 
+def test_pix_zero_loc():
+    r, c = 100, 200
+    ye, ze = chandra_aca.pixels_to_yagzag(r, c, pix_zero_loc='edge')
+    yc, zc = chandra_aca.pixels_to_yagzag(r, c, pix_zero_loc='center')
+
+    # Different by about 2.5 arcsec for sanity check
+    assert np.isclose(abs(ye - yc), 2.5, rtol=0, atol=0.02)
+    assert np.isclose(abs(ze - zc), 2.5, rtol=0, atol=0.02)
+
+    # Round trips r,c => y,z => r,c
+    re, ce = chandra_aca.yagzag_to_pixels(ye, ze, pix_zero_loc='edge')
+    rc, cc = chandra_aca.yagzag_to_pixels(yc, zc, pix_zero_loc='center')
+
+    # Interestingly these transforms do not round trip more accurately
+    # than about 0.01 pixels.
+    assert np.isclose(re - r, 0, rtol=0, atol=0.01)
+    assert np.isclose(rc - r, 0, rtol=0, atol=0.01)
+    assert np.isclose(ce - c, 0, rtol=0, atol=0.01)
+    assert np.isclose(cc - c, 0, rtol=0, atol=0.01)
+
+
 def test_aca_targ_transforms():
     """
     Observation request:

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -104,8 +104,8 @@ def pixels_to_yagzag(row, col, allow_bad=False, flight=False, t_aca=20,
     col = np.array(col)
 
     if pix_zero_loc == 'center':
-        # Transform row/col values to the convention where the lower/left
-        # corner is at 0.0.  This is needed for the _poly_convert below.
+        # Transform row/col values from 'center' convention to 'edge'
+        # convention, which is required for use in _poly_convert below.
         row = row + 0.5
         col = col + 0.5
     elif pix_zero_loc != 'edge':
@@ -143,13 +143,13 @@ def yagzag_to_pixels(yang, zang, allow_bad=False, pix_zero_loc='edge'):
     zang = np.array(zang)
     row, col = _poly_convert(yang, zang, ACA2PIX_coeff)
     if (not allow_bad and
-        (np.any(row > 511.5) or np.any(row < -512.5)
-         or np.any(col > 511.5) or np.any(col < -512.5))):
+        (np.any(row > 511.5) or np.any(row < -512.5) or
+         np.any(col > 511.5) or np.any(col < -512.5))):
         raise ValueError("Coordinate off CCD")
 
     if pix_zero_loc == 'center':
-        # Transform row/col values to the convention where integral values
-        # are at the center of the pixel.
+        # Transform row/col values from 'edge' convention (as returned
+        # by _poly_convert) to the 'center' convention requested by user.
         row = row - 0.5
         col = col - 0.5
     elif pix_zero_loc != 'edge':


### PR DESCRIPTION
This is useful for the simulator, and in general for any work where raw pixel values and centroids are being interposed.  The ACA PEA uses the `edge` convention which turns out to be mostly inconvenient.  I recall worrying about this for the pipeline, and I have a vague recollection that the aspect pipeline poly coeffs are off by 2.5 arcsec because row/col there use `center`.  (That *might* be completely wrong, but that's my recollection).

In any case we need to just be clear.
