### PR TITLE
Plot ACA star field more accurately using CCD row/col

### DIFF
--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -171,7 +171,8 @@ def _plot_field_stars(ax, stars, attitude, red_mag_lim=None, bad_stars=None):
 
 
 def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None,
-               red_mag_lim=None, quad_bound=True, grid=True, bad_stars=None):
+               red_mag_lim=None, quad_bound=True, grid=True, bad_stars=None,
+               plot_keepout=False):
     """
     Plot a catalog, a star field, or both in a matplotlib figure.
     If supplying a star field, an attitude must also be supplied.
@@ -194,6 +195,7 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
     :param bad_stars: boolean mask on 'stars' of those that don't meet minimum requirements
                       to be selected as acq stars.  If None, bad_stars will be set by a call
                       to bad_acq_stars().
+    :param plot_keepout: plot CCD area to be avoided in star selection (default=False)
     :returns: matplotlib figure
     """
     if stars is None:
@@ -247,7 +249,20 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
         ax.plot([-510, 510], [-0.5, -0.5], color='magenta', alpha=0.4)
         ax.plot([-0.5, -0.5], [-510, 510], color='magenta', alpha=0.4)
 
-    # plot stars
+    if plot_keepout:
+        # Plot grey area showing effective keep-out zones for stars.  Back off on
+        # outer limits by one pixel to improve rendered PNG slightly.
+        row_pad = 15
+        col_pad = 8
+        box = plt.Rectangle((-511, -511), 1022, 1022, edgecolor='none',
+                            facecolor='black', alpha=0.2, zorder=-1000)
+        ax.add_patch(box)
+        box = plt.Rectangle((-512 + row_pad, -512 + col_pad),
+                            1024 - row_pad * 2, 1024 - col_pad * 2,
+                            edgecolor='none', facecolor='white', zorder=-999)
+        ax.add_patch(box)
+
+    # Plot stars
     _plot_field_stars(ax, stars, attitude=attitude,
                       bad_stars=bad_stars, red_mag_lim=red_mag_lim)
     # plot starcheck catalog

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -209,7 +209,7 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
         bad_stars = bad_acq_stars(stars)
 
     fig = plt.figure(figsize=(5.325, 5.325))
-    fig.subplots_adjust(top=0.9)
+    fig.subplots_adjust(top=0.95)
 
     # Make an empty plot in row, col space
     ax = fig.add_subplot(1, 1, 1)

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -126,9 +126,11 @@ def _plot_field_stars(ax, stars, attitude, red_mag_lim=None, bad_stars=None):
         yags, zags = radec2yagzag(stars['RA_PMCORR'], stars['DEC_PMCORR'], quat)
         stars['yang'] = yags * 3600
         stars['zang'] = zags * 3600
-        rows, cols = yagzag_to_pixels(stars['yang'], stars['zang'], allow_bad=True)
-        stars['row'] = rows
-        stars['col'] = cols
+
+    # Update table to include row/col values corresponding to yag/zag
+    rows, cols = yagzag_to_pixels(stars['yang'], stars['zang'], allow_bad=True)
+    stars['row'] = rows
+    stars['col'] = cols
 
     # Initialize array of colors for the stars, default is black.  Use 'object'
     # type to not worry in advance about string length and also for Py2/3 compat.

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -58,7 +58,7 @@ def _plot_catalog_items(ax, catalog):
     acq_stars = cat[(cat['type'] == 'ACQ') | (cat['type'] == 'BOT')]
     fids = cat[cat['type'] == 'FID']
     mon_wins = cat[cat['type'] == 'MON']
-    print(cat)
+
     for row in cat:
         ax.annotate("%s" % row['idx'],
                     xy=(row['row'] + 120 / 5, row['col'] + 60 / 5),
@@ -68,6 +68,7 @@ def _plot_catalog_items(ax, catalog):
                facecolors='none',
                edgecolors='green',
                s=100)
+
     for acq_star in acq_stars:
         box = plt.Rectangle(
             (acq_star['row'] - acq_star['halfw'] / 5,
@@ -77,6 +78,7 @@ def _plot_catalog_items(ax, catalog):
             color='blue',
             fill=False)
         ax.add_patch(box)
+
     for mon_box in mon_wins:
         # starcheck convention was to plot monitor boxes at 2X halfw
         box = plt.Rectangle(
@@ -87,6 +89,7 @@ def _plot_catalog_items(ax, catalog):
             color='orange',
             fill=False)
         ax.add_patch(box)
+
     ax.scatter(fids['row'], fids['col'],
                facecolors='none',
                edgecolors='red',
@@ -206,6 +209,7 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
 
     # Start with an empty plot that just has the tick labels for yag/zag
     ax_yz = fig.add_subplot(1, 1, 1)
+    plt.subplots_adjust(top=0.95, right=0.95)
     ax_yz.set_xlim(2900, -2900)
     ax_yz.set_ylim(-2900, 2900)
     ax_yz.grid()

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -209,27 +209,13 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
         bad_stars = bad_acq_stars(stars)
 
     fig = plt.figure(figsize=(5.325, 5.325))
+    fig.subplots_adjust(top=0.9)
 
-    # Start with an empty plot that just has the tick labels for yag/zag
-    ax_yz = fig.add_subplot(1, 1, 1)
-    plt.subplots_adjust(top=0.95, right=0.95)
-    ax_yz.set_xlim(2900, -2900)
-    ax_yz.set_ylim(-2900, 2900)
-    ax_yz.grid()
-    ax_yz.set_xlabel("Yag (arcsec)")
-    ax_yz.set_ylabel("Zag (arcsec)")
-    [l.set_rotation(90) for l in ax_yz.get_yticklabels()]
-
-    # Make the "real" plot box in pixels which exactly overlays the yag/zag
-    # version.  The yag/zag tick labels will be approximate in pixel space
-    # (though good enough at this resolution).  The star and CCD-related
-    # plotting (all in row/col) will be *exact*.
-    ax = fig.add_axes(ax_yz.get_position(), frameon=False)
+    # Make an empty plot in row, col space
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_aspect('equal')
-    ax.get_xaxis().set_visible(False)
-    ax.get_yaxis().set_visible(False)
-    plt.xlim(-579.7, 591.4)  # Matches 2900, -2900
-    plt.ylim(-580.6, 590.4)  # Matches -2900, 2900
+    plt.xlim(-580, 590)  # Matches -2900, 2900 arcsec roughly
+    plt.ylim(-580, 590)
 
     # plot the box and set the labels
     b1hw = 512
@@ -245,6 +231,21 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
                np.array([2400, 2100, 1800, 1500, 1200]) / 5,
                c='orange', edgecolors='none',
                s=symsize(np.array([10.0, 9.0, 8.0, 7.0, 6.0])))
+
+    # Manually set ticks and grid to specified yag/zag values
+    yz_ticks = [-2000, -1000, 0, 1000, 2000]
+    zeros = [0, 0, 0, 0, 0]
+    r, c = yagzag_to_pixels(yz_ticks, zeros)
+    ax.set_xticks(r)
+    ax.set_xticklabels(yz_ticks)
+    r, c = yagzag_to_pixels(zeros, yz_ticks)
+    ax.set_yticks(c)
+    ax.set_yticklabels(yz_ticks)
+    ax.grid()
+
+    ax.set_xlabel("Yag (arcsec)")
+    ax.set_ylabel("Zag (arcsec)")
+    [label.set_rotation(90) for label in ax.get_yticklabels()]
 
     if quad_bound:
         ax.plot([-510, 510], [-0.5, -0.5], color='magenta', alpha=0.4)

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -248,8 +248,8 @@ def plot_stars(attitude, catalog=None, stars=None, title=None, starcat_time=None
     [label.set_rotation(90) for label in ax.get_yticklabels()]
 
     if quad_bound:
-        ax.plot([-510, 510], [-0.5, -0.5], color='magenta', alpha=0.4)
-        ax.plot([-0.5, -0.5], [-510, 510], color='magenta', alpha=0.4)
+        ax.plot([-511, 511], [0, 0], color='magenta', alpha=0.4)
+        ax.plot([0, 0], [-511, 511], color='magenta', alpha=0.4)
 
     if plot_keepout:
         # Plot grey area showing effective keep-out zones for stars.  Back off on

--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -130,8 +130,9 @@ def _plot_field_stars(ax, stars, attitude, red_mag_lim=None, bad_stars=None):
         stars['row'] = rows
         stars['col'] = cols
 
-    # Initialize array of colors for the stars, default is black
-    colors = np.zeros(len(stars), dtype='U20')
+    # Initialize array of colors for the stars, default is black.  Use 'object'
+    # type to not worry in advance about string length and also for Py2/3 compat.
+    colors = np.zeros(len(stars), dtype='object')
     colors[:] = 'black'
 
     colors[bad_stars] = BAD_STAR_COLOR


### PR DESCRIPTION
Plot an ACA star field more accurately using CCD row/col as the fundamental plotting coordinates.  This makes all the critical boundaries be rectilinear on the plot, allowing for accurate visual comparison of star positions to those boundaries.

The tick marks and labels are still in yag/zag arcsec for visual reference (yag/zag is, in fact, more useful information for the viewer of the plot).  These are approximate but in most cases are within 10 arcsec (about one image pixel in the starcheck rendered PNG).

This adds a `plot_keepout` flag to enable plotting a gray area in the edge pixels where stars should not be selected.  It is False by default but should probably be enabled for starcheck.