### PR TITLE
Add functions for fast attitude determination based on star data

### DIFF
--- a/chandra_aca/attitude.py
+++ b/chandra_aca/attitude.py
@@ -53,9 +53,9 @@ def calc_roll(yag, zag, yag_obs, zag_obs, sigma=None):
 def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
     """Calc S/C delta roll, pitch, and yaw for observed star positions relative to reference.
 
-    This function computes a S/C delta roll that transforms the reference star
-    positions yag/zag into the observed positions yag_obs/zag_obs.  The units
-    for these values must be in arcsec.
+    This function computes a S/C delta roll/pitch/yaw that transforms the
+    reference star positions yag/zag into the observed positions
+    yag_obs/zag_obs.  The units for these values must be in arcsec.
 
     The inputs are assumed to be a list or array that corresponds to a single
     readout of at least two stars.
@@ -69,12 +69,14 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
     star inputs then one can supply an array of sigma values corresponding
     to each star.
 
-    :param yag: reference yag (list or array)
-    :param zag: reference zag (list or array)
-    :param yag_obs: observed yag (list or array)
-    :param zag_obs: observed zag (list or array)
+    :param yag: reference yag (list or array, arcsec)
+    :param zag: reference zag (list or array, arcsec)
+    :param yag_obs: observed yag (list or array, arcsec)
+    :param zag_obs: observed zag (list or array, arcsec)
+    :param sigma: centroid uncertainties (None or list or array, arcsec)
+    :param iter: number of iterations (default=1, leave this alone usually)
 
-    :returns: roll (deg)
+    :returns: roll, pitch, yaw (degrees)
 
     """
     yag = np.array(yag)
@@ -104,7 +106,6 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
     dyag = yag_obs_avg - yag_avg
     dzag = zag_obs_avg - zag_avg
 
-    # wrong here.
     pitch = dzag / 3600
     yaw = -dyag / 3600
 

--- a/chandra_aca/attitude.py
+++ b/chandra_aca/attitude.py
@@ -50,31 +50,33 @@ def calc_roll(yag, zag, yag_obs, zag_obs, sigma=None):
     return np.degrees(theta)
 
 
-def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
+def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None):
     """Calc S/C delta roll, pitch, and yaw for observed star positions relative to reference.
 
     This function computes a S/C delta roll/pitch/yaw that transforms the
     reference star positions yag/zag into the observed positions
     yag_obs/zag_obs.  The units for these values must be in arcsec.
 
-    The inputs are assumed to be a list or array that corresponds to a single
-    readout of at least two stars.
+    The ``yag`` and ``zag`` values correspond to the reference star catalog
+    positions.  These must be a 1-d list or array of length M (number of
+    stars).
+
+    The ``yag_obs`` and ``zag_obs`` values must be either a 1-d or 2-d array
+    with shape M (single readout of M stars) or shape N x M (N rows of M
+    stars).
+
+    The ``sigma`` parameter can be None or a 1-d array of length M.
 
     The algorithm is a simple but fast linear least-squared solution which uses
     a small angle assumption to linearize the rotation matrix from
     [[cos(th) -sin(th)], [sin(th), cos(th)]] to [[1, -th], [th, 1]].
     In practice anything below 1.0 degree is fine.
 
-    If there are different measurement uncertainties for the different
-    star inputs then one can supply an array of sigma values corresponding
-    to each star.
-
     :param yag: reference yag (list or array, arcsec)
     :param zag: reference zag (list or array, arcsec)
     :param yag_obs: observed yag (list or array, arcsec)
     :param zag_obs: observed zag (list or array, arcsec)
     :param sigma: centroid uncertainties (None or list or array, arcsec)
-    :param iter: number of iterations (default=1, leave this alone usually)
 
     :returns: roll, pitch, yaw (degrees)
 
@@ -83,8 +85,43 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
     zag = np.array(zag)
     yag_obs = np.array(yag_obs)
     zag_obs = np.array(zag_obs)
-    
-    weights = None if (sigma is None) else 1 / sigma
+
+    if yag.ndim != 1 or zag.ndim != 1 or yag.shape != zag.shape:
+        raise ValueError('yag and zag must be 1-d and equal length')
+
+    if (yag_obs.ndim not in (1, 2) or zag.ndim not in (1, 2) or
+            yag_obs.shape != zag_obs.shape):
+        raise ValueError('yag_obs and zag_obs must be 1-d or 2-d and equal shape')
+
+    n_stars = len(yag)
+    if yag_obs.shape[-1] != n_stars or zag.shape[-1] != n_stars:
+        raise ValueError('inconsistent number of stars in yag_obs or zag_obs')
+
+    one_d = yag_obs.ndim == 1
+    if one_d:
+        yag_obs.shape = 1, n_stars
+        zag_obs.shape = 1, n_stars
+
+    outs = []
+    for yo, zo in zip(yag_obs, zag_obs):
+        out = _calc_roll_pitch_yaw(yag, zag, yo, zo, sigma=sigma)
+        outs.append(out)
+
+    if one_d:
+        roll, pitch, yaw = outs[0]
+    else:
+        vals = np.array(outs)
+        roll, pitch, yaw = vals[:, 0], vals[:, 1], vals[:, 2]
+
+    return roll, pitch, yaw
+
+
+def _calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
+    """
+    Internal version that does the real work of calc_roll_pitch_yaw and
+    works on only one sample at a time.
+    """
+    weights = None if (sigma is None) else 1 / np.array(sigma)
     yag_avg = np.average(yag, weights=weights)
     zag_avg = np.average(zag, weights=weights)
     yag_obs_avg = np.average(yag_obs, weights=weights)
@@ -96,8 +133,8 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
                      sigma)
 
     # Roll the whole constellation to match the reference
-    yag_obs, zag_obs = rot(roll) @ np.array([yag_obs,
-                                             zag_obs])
+    yag_obs, zag_obs = _rot(roll) @ np.array([yag_obs,
+                                              zag_obs])
 
     # Now remove the mean linear offset
     yag_obs_avg = np.average(yag_obs, weights=weights)
@@ -115,7 +152,7 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
         yag_obs -= dyag
         zag_obs -= dzag
 
-        dr, dp, dy = calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma, iter - 1)
+        dr, dp, dy = _calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma, iter - 1)
         roll += dr
         pitch += dp
         yaw += dy
@@ -123,8 +160,60 @@ def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
     return roll, pitch, yaw
 
 
-def rot(roll):
+def _rot(roll):
     theta = np.radians(roll)
     out = np.array([[np.cos(theta), -np.sin(theta)],
                     [np.sin(theta), np.cos(theta)]])
+    return out
+
+
+def calc_att(att, yag, zag, yag_obs, zag_obs, sigma=None):
+    """Calc S/C attitude for observed star positions relative to reference.
+
+    This function computes a S/C attitude that transforms the
+    reference star positions yag/zag into the observed positions
+    yag_obs/zag_obs.  The units for these values must be in arcsec.
+
+    The attitude ``att`` is the reference attitude for the reference star
+    catalog.  It can be any value that initializes a Quat object.
+
+    The ``yag`` and ``zag`` values correspond to the reference star catalog
+    positions.  These must be a 1-d list or array of length M (number of
+    stars).
+
+    The ``yag_obs`` and ``zag_obs`` values must be either a 1-d or 2-d array
+    with shape M (single readout of M stars) or shape N x M (N rows of M
+    stars).
+
+    The ``sigma`` parameter can be None or a 1-d array of length M.
+
+    The algorithm is a simple but fast linear least-squared solution which uses
+    a small angle assumption to linearize the rotation matrix from
+    [[cos(th) -sin(th)], [sin(th), cos(th)]] to [[1, -th], [th, 1]].
+    In practice anything below 1.0 degree is fine.
+
+    :param att: reference attitude (Quat-compatible)
+    :param yag: reference yag (list or array, arcsec)
+    :param zag: reference zag (list or array, arcsec)
+    :param yag_obs: observed yag (list or array, arcsec)
+    :param zag_obs: observed zag (list or array, arcsec)
+    :param sigma: centroid uncertainties (None or list or array, arcsec)
+
+    :returns: Quat or list of Quat
+
+    """
+    from Quaternion import Quat
+    q_att = Quat(att)
+
+    rolls, pitches, yaws = calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma)
+
+    if isinstance(rolls, np.ndarray) and rolls.ndim >= 1:
+        out = []
+        for roll, pitch, yaw in zip(rolls, pitches, yaws):
+            dq = Quat([yaw, -pitch, roll])
+            out.append(q_att * dq)
+    else:
+        dq = Quat([yaws, -pitches, rolls])
+        out = q_att * dq
+
     return out

--- a/chandra_aca/attitude.py
+++ b/chandra_aca/attitude.py
@@ -3,6 +3,9 @@ Calculate attitude based on star centroid values using a fast linear
 least-squares method.
 
 Note this requires Python 3.5+.
+
+Validation:
+http://nbviewer.jupyter.org/url/asc.harvard.edu/mta/ASPECT/ipynb/chandra_aca/calc_att_validate.ipynb
 """
 import numpy as np
 

--- a/chandra_aca/attitude.py
+++ b/chandra_aca/attitude.py
@@ -1,0 +1,128 @@
+"""
+Calculate attitude based on star centroid values using a fast linear
+least-squares method.
+
+Note this requires Python 3.5+.
+"""
+import numpy as np
+
+
+def calc_roll(yag, zag, yag_obs, zag_obs, sigma=None):
+    """Calc S/C delta roll for observed star positions relative to reference.
+
+    This function computes a S/C delta roll that transforms the reference star
+    positions yag/zag into the observed positions yag_obs/zag_obs.  The units
+    for these values can be anything (arcsec, deg) but must all be consistent.
+
+    The inputs are assumed to be a list or array that corresponds to a single
+    readout of at least two stars.
+
+    The algorithm is a simple but fast linear least-squared solution which uses
+    a small angle assumption to linearize the rotation matrix from
+    [[cos(th) -sin(th)], [sin(th), cos(th)]] to [[1, -th], [th, 1]].
+    In practice anything below 1.0 degree is fine.
+
+    If there are different measurement uncertainties for the different
+    star inputs then one can supply an array of sigma values corresponding
+    to each star.
+
+    :param yag: reference yag (list or array)
+    :param zag: reference zag (list or array)
+    :param yag_obs: observed yag (list or array)
+    :param zag_obs: observed zag (list or array)
+
+    :returns: roll (deg)
+
+    """
+    yag = np.asarray(yag)
+    zag = np.asarray(zag)
+    yag_obs = np.asarray(yag_obs)
+    zag_obs = np.asarray(zag_obs)
+
+    if sigma is not None:
+        sigma = np.asarray(sigma)
+        yag = yag / sigma
+        zag = zag / sigma
+        yag_obs = yag_obs / sigma
+        zag_obs = zag_obs / sigma
+
+    theta = -(yag @ zag_obs - zag @ yag_obs) / (yag @ yag + zag @ zag)
+    return np.degrees(theta)
+
+
+def calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma=None, iter=1):
+    """Calc S/C delta roll, pitch, and yaw for observed star positions relative to reference.
+
+    This function computes a S/C delta roll that transforms the reference star
+    positions yag/zag into the observed positions yag_obs/zag_obs.  The units
+    for these values must be in arcsec.
+
+    The inputs are assumed to be a list or array that corresponds to a single
+    readout of at least two stars.
+
+    The algorithm is a simple but fast linear least-squared solution which uses
+    a small angle assumption to linearize the rotation matrix from
+    [[cos(th) -sin(th)], [sin(th), cos(th)]] to [[1, -th], [th, 1]].
+    In practice anything below 1.0 degree is fine.
+
+    If there are different measurement uncertainties for the different
+    star inputs then one can supply an array of sigma values corresponding
+    to each star.
+
+    :param yag: reference yag (list or array)
+    :param zag: reference zag (list or array)
+    :param yag_obs: observed yag (list or array)
+    :param zag_obs: observed zag (list or array)
+
+    :returns: roll (deg)
+
+    """
+    yag = np.array(yag)
+    zag = np.array(zag)
+    yag_obs = np.array(yag_obs)
+    zag_obs = np.array(zag_obs)
+    
+    weights = None if (sigma is None) else 1 / sigma
+    yag_avg = np.average(yag, weights=weights)
+    zag_avg = np.average(zag, weights=weights)
+    yag_obs_avg = np.average(yag_obs, weights=weights)
+    zag_obs_avg = np.average(zag_obs, weights=weights)
+
+    dyag = yag_obs_avg - yag_avg
+    dzag = zag_obs_avg - zag_avg
+
+    pitch = dzag / 3600
+    yaw = -dyag / 3600
+
+    # Remove the mean linear offset
+    yag_obs -= yag_obs_avg
+    zag_obs -= zag_obs_avg
+    yag -= yag_avg
+    zag -= zag_avg
+    roll = calc_roll(yag, zag, yag_obs, zag_obs, sigma)
+
+    if iter > 0:
+        # Allow for recursive iterations to refine estimate.  In practice a single
+        # additional pass is enough.
+        yag_obs, zag_obs = rot(roll) @ np.array([yag_obs,
+                                                 zag_obs])
+        dr, dp, dy = calc_roll_pitch_yaw(yag, zag, yag_obs, zag_obs, sigma, iter - 1)
+        roll += dr
+        pitch += dp
+        yaw += dy
+
+    if 1:
+        print('YAG:', ['{:3f}'.format(x) for x in yag])
+        print('ZAG:', ['{:3f}'.format(x) for x in zag])
+        print('dYAG:', ['{:3f}'.format(x) for x in yag - yag_obs])
+        print('dZAG:', ['{:3f}'.format(x) for x in zag - zag_obs])
+
+    print(roll*3600, pitch*3600, yaw*3600)
+    return roll, pitch, yaw
+
+
+def rot(roll):
+    theta = np.radians(roll)
+    out = np.array([[np.cos(theta), -np.sin(theta)],
+                    [np.sin(theta), np.cos(theta)]])
+    return out

--- a/chandra_aca/tests/test_attitude.py
+++ b/chandra_aca/tests/test_attitude.py
@@ -46,7 +46,7 @@ stars = [[(-1, 1), (1, 1), (0, 0), (1, -1)],
 
 
 @pytest.mark.parametrize('stars', stars)
-@pytest.mark.parametrize('roll', [-10000, 10, 100])
+@pytest.mark.parametrize('roll', [-1000, 10, 100])
 @pytest.mark.parametrize('pitch', [-50, 8, 20])
 @pytest.mark.parametrize('yaw', [-20, -8, 50])
 def test_calc_roll_pitch_yaw(stars, pitch, yaw, roll):
@@ -77,10 +77,7 @@ def test_calc_roll_pitch_yaw(stars, pitch, yaw, roll):
         zags_obs.append(zag * 3600)
 
     out_roll, out_pitch, out_yaw = calc_roll_pitch_yaw(yags, zags, yags_obs, zags_obs)
-    # Computed pitch, yaw, roll within 1% of actual
-    assert np.isclose(roll, out_roll, atol=0.2 / 3600, rtol=0.0)
-    assert np.isclose(pitch, out_pitch, atol=0.2 / 3600, rtol=0.0)
-    assert np.isclose(yaw, out_yaw, atol=0.2 / 3600, rtol=0.0)
-    # print(roll, out_roll)
-    # print(pitch, out_pitch)
-    # print(yaw, out_yaw)
+    # Computed pitch, yaw, roll within 0.5 arcsec in roll, 0.02 arcsec pitch/yaw
+    assert np.isclose(roll, out_roll, atol=0.5 / 3600, rtol=0.0)
+    assert np.isclose(pitch, out_pitch, atol=0.02 / 3600, rtol=0.0)
+    assert np.isclose(yaw, out_yaw, atol=0.02 / 3600, rtol=0.0)

--- a/chandra_aca/tests/test_attitude.py
+++ b/chandra_aca/tests/test_attitude.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+
+from Quaternion import Quat
+from Ska.quatutil import radec2yagzag
+
+from ..attitude import calc_roll, calc_roll_pitch_yaw
+
+
+@pytest.mark.parametrize('roll', [-1, -0.1, 50 / 3600, 0.1])
+def test_calc_roll(roll):
+    stars = [(-1, 1),  # ra, dec in deg
+             (1, 1),
+             (0, 0),
+             (1, -1)]
+
+    q0 = Quat([0, 0, 45])
+    dq = Quat([0, 0, roll])
+    assert np.isclose(dq.roll, roll)
+    q0_roll = q0 * dq
+    assert np.isclose(q0_roll.roll, q0.roll + roll)
+
+    yags = []
+    zags = []
+    yags_obs = []
+    zags_obs = []
+    for ra, dec in stars:
+        yag, zag = radec2yagzag(ra, dec, q0)
+        yags.append(yag)
+        zags.append(zag)
+
+        yag, zag = radec2yagzag(ra, dec, q0_roll)
+        yags_obs.append(yag)
+        zags_obs.append(zag)
+
+    out_roll = calc_roll(yags, zags, yags_obs, zags_obs)
+    # Computed roll is within 0.1% of actual roll
+    assert np.isclose(roll, out_roll, atol=0.0, rtol=0.001)
+
+# Star fields.  This includes a "normal" set of stars and
+# a weird set with just two stars that are close together
+# but far off axis.  In this case the rotation will
+# manifest as a linear offset.
+stars = [[(-1, 1), (1, 1), (0, 0), (1, -1)],
+         [(-0.1, 1), (0.1, 1)]]
+
+
+@pytest.mark.parametrize('stars', stars)
+@pytest.mark.parametrize('roll', [-10000, 10, 100])
+@pytest.mark.parametrize('pitch', [-50, 8, 20])
+@pytest.mark.parametrize('yaw', [-20, -8, 50])
+def test_calc_roll_pitch_yaw(stars, pitch, yaw, roll):
+    roll /= 3600
+    pitch /= 3600
+    yaw /= 3600
+
+    q0 = Quat([0, 0, 45])
+    dq = Quat([yaw, -pitch, roll])
+    assert np.isclose(dq.roll, roll)
+    assert np.isclose(dq.pitch, pitch)
+    assert np.isclose(dq.yaw, yaw)
+
+    q0_offset = q0 * dq
+    assert np.isclose(q0_offset.roll, q0.roll + roll)
+
+    yags = []
+    zags = []
+    yags_obs = []
+    zags_obs = []
+    for ra, dec in stars:
+        yag, zag = radec2yagzag(ra, dec, q0)
+        yags.append(yag * 3600)
+        zags.append(zag * 3600)
+
+        yag, zag = radec2yagzag(ra, dec, q0_offset)
+        yags_obs.append(yag * 3600)
+        zags_obs.append(zag * 3600)
+
+    out_roll, out_pitch, out_yaw = calc_roll_pitch_yaw(yags, zags, yags_obs, zags_obs)
+    # Computed pitch, yaw, roll within 1% of actual
+    assert np.isclose(roll, out_roll, atol=0.2 / 3600, rtol=0.0)
+    assert np.isclose(pitch, out_pitch, atol=0.2 / 3600, rtol=0.0)
+    assert np.isclose(yaw, out_yaw, atol=0.2 / 3600, rtol=0.0)
+    # print(roll, out_roll)
+    # print(pitch, out_pitch)
+    # print(yaw, out_yaw)

--- a/chandra_aca/tests/test_attitude.py
+++ b/chandra_aca/tests/test_attitude.py
@@ -4,7 +4,7 @@ import pytest
 from Quaternion import Quat
 from Ska.quatutil import radec2yagzag
 
-from ..attitude import calc_roll, calc_roll_pitch_yaw
+from ..attitude import calc_roll, calc_roll_pitch_yaw, calc_att
 
 
 @pytest.mark.parametrize('roll', [-1, -0.1, 50 / 3600, 0.1])
@@ -76,8 +76,106 @@ def test_calc_roll_pitch_yaw(stars, pitch, yaw, roll):
         yags_obs.append(yag * 3600)
         zags_obs.append(zag * 3600)
 
-    out_roll, out_pitch, out_yaw = calc_roll_pitch_yaw(yags, zags, yags_obs, zags_obs)
+    sigma = np.arange(len(yags)) + 1
+    out_roll, out_pitch, out_yaw = calc_roll_pitch_yaw(yags, zags, yags_obs, zags_obs, sigma)
     # Computed pitch, yaw, roll within 0.5 arcsec in roll, 0.02 arcsec pitch/yaw
     assert np.isclose(roll, out_roll, atol=0.5 / 3600, rtol=0.0)
     assert np.isclose(pitch, out_pitch, atol=0.02 / 3600, rtol=0.0)
     assert np.isclose(yaw, out_yaw, atol=0.02 / 3600, rtol=0.0)
+
+
+def get_data_2d():
+    stars0 = stars[0]
+
+    q0 = Quat([0, 0, 45])
+
+    yags = []
+    zags = []
+    for ra, dec in stars0:
+        yag, zag = radec2yagzag(ra, dec, q0)
+        yags.append(yag * 3600)
+        zags.append(zag * 3600)
+
+    yags_obs_list = []
+    zags_obs_list = []
+    times = np.linspace(0, 1000, 10)
+    rolls = np.sin(2 * np.pi * times / 666) * 100 / 3600
+    pitches = np.sin(2 * np.pi * times / 1000) * 50 / 3600
+    yaws = np.sin(2 * np.pi * times / 707) * 30 / 3600
+
+    qs = []
+    for roll, pitch, yaw in zip(rolls, pitches, yaws):
+        dq = Quat([yaw, -pitch, roll])
+        q0_offset = q0 * dq
+        qs.append(q0_offset)
+
+        yags_obs = []
+        zags_obs = []
+        for ra, dec in stars0:
+            yag, zag = radec2yagzag(ra, dec, q0_offset)
+            yags_obs.append(yag * 3600)
+            zags_obs.append(zag * 3600)
+        yags_obs_list.append(yags_obs)
+        zags_obs_list.append(zags_obs)
+
+    return q0, rolls, pitches, yaws, qs, yags, zags, yags_obs_list, zags_obs_list
+
+
+def test_calc_roll_pitch_yaw_2d():
+    q0, rolls, pitches, yaws, qs, yags, zags, yags_obs_list, zags_obs_list = get_data_2d()
+    # Test direct roll/pitch/yaw computation
+    out = calc_roll_pitch_yaw(yags, zags, yags_obs_list, zags_obs_list)
+    out_rolls, out_pitches, out_yaws = out
+
+    # Computed pitch, yaw, roll within 0.5 arcsec in roll, 0.02 arcsec pitch/yaw
+    assert np.allclose(rolls, out_rolls, atol=0.5 / 3600, rtol=0.0)
+    assert np.allclose(pitches, out_pitches, atol=0.02 / 3600, rtol=0.0)
+    assert np.allclose(yaws, out_yaws, atol=0.02 / 3600, rtol=0.0)
+
+
+def test_calc_att():
+    """Test attitude quaternion computation"""
+    q0, rolls, pitches, yaws, qs, yags, zags, yags_obs_list, zags_obs_list = get_data_2d()
+    q_outs = calc_att(q0, yags, zags, yags_obs_list, zags_obs_list)
+    assert len(qs) == len(q_outs)
+    for q, q_out in zip(qs, q_outs):
+        dq = q.dq(q_out)
+        assert np.abs(dq.roll0) < 0.5 / 3600
+        assert np.abs(dq.pitch) < 0.02 / 3600
+        assert np.abs(dq.yaw) < 0.02 / 3600
+
+    # Test attitude quaternion computation
+    q_out = calc_att(q0, yags, zags, yags_obs_list[0], zags_obs_list[0])
+    assert isinstance(q_out, Quat)
+    dq = qs[0].dq(q_out)
+    assert np.abs(dq.roll0) < 0.5 / 3600
+    assert np.abs(dq.pitch) < 0.02 / 3600
+    assert np.abs(dq.yaw) < 0.02 / 3600
+
+
+def test_calc_roll_pitch_yaw_sigma():
+    q0, rolls, pitches, yaws, qs, yags, zags, yags_obs_list, zags_obs_list = get_data_2d()
+    yags_obs_list = np.array(yags_obs_list)
+    zags_obs_list = np.array(zags_obs_list)
+
+    # Zero noise
+    out = calc_roll_pitch_yaw(yags, zags, yags_obs_list, zags_obs_list)
+    out_rolls, out_pitches, out_yaws = out
+    dr = rolls - out_rolls
+    assert np.std(dr) < 0.2 / 3600
+
+    # Linear offset from -25 to +25 arcsec (hot pixel?) with no sigma adjustment
+    sigma = [50, 1, 1, 1]
+    yags_obs_list[:, 0] += np.linspace(-25, 25, len(zags_obs_list))
+    zags_obs_list[:, 0] += np.linspace(-25, 25, len(zags_obs_list))
+
+    out = calc_roll_pitch_yaw(yags, zags, yags_obs_list, zags_obs_list)
+    out_rolls, out_pitches, out_yaws = out
+    dr = rolls - out_rolls
+    assert np.std(dr) > 280 / 3600
+
+    # Linear offset from -25 to +25 arcsec (hot pixel?) with sigma = 50 for bad slot
+    out = calc_roll_pitch_yaw(yags, zags, yags_obs_list, zags_obs_list, sigma=sigma)
+    out_rolls, out_pitches, out_yaws = out
+    dr = rolls - out_rolls
+    assert np.std(dr) < 1 / 3600


### PR DESCRIPTION
This takes about 0.2 msec to compute a roll/pitch/yaw offset.

See [calc_att_validate.ipynb](http://nbviewer.jupyter.org/url/asc.harvard.edu/mta/ASPECT/ipynb/chandra_aca/calc_att_validate.ipynb) for validation plots.