### PR TITLE
Cast row0, col0 vals to int

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,6 +1,6 @@
 from .transform import *
 
-__version__ = '3.14'
+__version__ = '3.14.1'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -62,7 +62,7 @@ class ACAImage(np.ndarray):
             imgax = 'IMG' + ax.upper()
             meta.setdefault(imgax, 0)
             if ax in kwargs:
-                meta[imgax] = kwargs.pop(ax)
+                meta[imgax] = int(kwargs.pop(ax))
 
         try:
             arr = np.array(*args, **kwargs)
@@ -189,7 +189,7 @@ class ACAImage(np.ndarray):
 
     @row0.setter
     def row0(self, value):
-        self.meta['IMGROW0'] = value
+        self.meta['IMGROW0'] = int(value)
 
     @property
     def col0(self):
@@ -197,4 +197,4 @@ class ACAImage(np.ndarray):
 
     @col0.setter
     def col0(self, value):
-        self.meta['IMGCOL0'] = value
+        self.meta['IMGCOL0'] = int(value)

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -25,8 +25,10 @@ def test_init():
     assert a.meta == {'IMGROW0': 1, 'IMGCOL0': 2}
 
     # Init as zeroes with shape
-    a = ACAImage(shape=(1024, 1024), row0=-512, col0=-512)
+    a = ACAImage(shape=(1024, 1024), row0=-512.0, col0=-512.0)
     assert np.all(a == np.zeros((1024, 1024)))
+    assert type(a.row0) is int
+    assert type(a.col0) is int
 
     a = ACAImage(im6, meta={'IMGROW0': 1, 'IMGCOL0': 2})
     assert a.row0 == 1
@@ -35,10 +37,12 @@ def test_init():
 
 def test_row_col_set():
     a = ACAImage(im6)
-    a.row0 = -10
-    a.col0 = -20
+    a.row0 = -10.0
+    a.col0 = -20.0
     assert a.row0 == -10
     assert a.col0 == -20
+    assert type(a.row0) is int
+    assert type(a.col0) is int
 
 
 def test_meta_set():

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -101,7 +101,7 @@ def test_slice():
     assert np.all(a == im60)
 
     # Slice using an ACAImage
-    a2 = ACAImage(im8, row0=1, col0=1)
+    a2 = ACAImage(im8, row0=1.0, col0=1.0)
     assert np.all(a2[a] == im8[0:6, 1:7])
 
     # Set slice using an ACAImage


### PR DESCRIPTION
Currently one can set row0, col0 to any number including a float (e.g. `img.row0 = np.round(..)`, which is still a float).  For recent versions of numpy slicing on floats is not allowed.