### PR TITLE
Fix latent bug - fancy indexing did not work

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -62,7 +62,7 @@ class ACAImage(np.ndarray):
             imgax = 'IMG' + ax.upper()
             meta.setdefault(imgax, 0)
             if ax in kwargs:
-                meta[imgax] = int(kwargs.pop(ax))
+                meta[imgax] = np.int64(kwargs.pop(ax))
 
         try:
             arr = np.array(*args, **kwargs)
@@ -189,7 +189,7 @@ class ACAImage(np.ndarray):
 
     @row0.setter
     def row0(self, value):
-        self.meta['IMGROW0'] = int(value)
+        self.meta['IMGROW0'] = np.int64(value)
 
     @property
     def col0(self):
@@ -197,4 +197,4 @@ class ACAImage(np.ndarray):
 
     @col0.setter
     def col0(self, value):
-        self.meta['IMGCOL0'] = int(value)
+        self.meta['IMGCOL0'] = np.int64(value)

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -27,8 +27,8 @@ def test_init():
     # Init as zeroes with shape
     a = ACAImage(shape=(1024, 1024), row0=-512.0, col0=-512.0)
     assert np.all(a == np.zeros((1024, 1024)))
-    assert type(a.row0) is int
-    assert type(a.col0) is int
+    assert type(a.row0) is np.int64
+    assert type(a.col0) is np.int64
 
     a = ACAImage(im6, meta={'IMGROW0': 1, 'IMGCOL0': 2})
     assert a.row0 == 1
@@ -41,8 +41,8 @@ def test_row_col_set():
     a.col0 = -20.0
     assert a.row0 == -10
     assert a.col0 == -20
-    assert type(a.row0) is int
-    assert type(a.col0) is int
+    assert type(a.row0) is np.int64
+    assert type(a.col0) is np.int64
 
 
 def test_meta_set():
@@ -109,6 +109,17 @@ def test_slice():
     im80 = im8.copy()
     im80[0:6, 1:7] = 0
     assert np.all(a2 == im80)
+
+
+def test_slice_list():
+    a = ACAImage(im6, row0=1, col0=2)
+    r = [1, 2, 3]
+    c = [3, 4, 5]
+    a2 = a[r, c]
+    assert np.all(a2 == im6[r, c])
+
+    a2 = a.aca[r, c]
+    assert np.all(a2 == im6[r - a.row0, c - a.col0])
 
 
 def test_meta_ref():


### PR DESCRIPTION
This relies on the fact that `np.int64(5) - [1, 2, 3]` works, i.e. `np.int64(..)` will broadcast with a Python list.  Code in `annie` was accidentally working because `row0` and `col0` were `np.float64`, and so the broadcasting was working.  When `row0` was changed to `int` in #33, this broke `annie` because `int + list` fails.