### PR TITLE
Add 2022 fit coefficients and hack to apply for warm_frac above 0.27

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,6 +1,6 @@
 from .transform import *
 
-__version__ = '3.16.1'
+__version__ = '3.17'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -74,6 +74,15 @@ SOTA_FIT_ONLY_1P5_NO_MS = [4.73283,  # scl0
                            -0.37074,  # off2
                            ]
 
+SOTA_FIT_2022 = [7.78471,  # scl0
+                 -3.70337,  # scl1
+                 -2.84246,  # scl2
+                 -3.19593,  # off0
+                 2.86478,  # off1
+                 1.28957,  # off2
+                 ]
+
+
 # Default global values using NO_MS settings.  Kinda ugly.
 def set_acq_model_ms_filter(ms_enabled=False):
     """
@@ -297,10 +306,14 @@ def model_acq_success_prob(mag, warm_frac, color=0, halfwidth=120):
 
     m10 = mag - 10.0
     box120 = (halfwidth - 120) / 120  # Normalized halfwidth, 0.0 for halfwidth=120
+    color1p5 = color == 1.5
+    # TEMPORARY hack to select 2022.  warm_frac < 0.27 for flight data circa Aug 2017.
+    warmfrac27 = warm_frac > 0.27
 
     p_fail = np.zeros_like(mag)
-    for mask, fit_pars in ((color == 1.5, SOTA_FIT_ONLY_1P5),
-                           (color != 1.5, SOTA_FIT_NO_1P5)):
+    for mask, fit_pars in ((color1p5 & ~warmfrac27, SOTA_FIT_ONLY_1P5),
+                           (~color1p5 & ~warmfrac27, SOTA_FIT_NO_1P5),
+                           (warmfrac27, SOTA_FIT_2022)):
         if np.any(mask):
             scale = np.polyval(fit_pars[0:3][::-1], m10)
             offset = np.polyval(fit_pars[3:6][::-1], m10)


### PR DESCRIPTION
See the final plots in the link below comparing to the PEA 2022 test data:
  https://github.com/sot/aca_stats/blob/a2dbe18d/fit_flight_acq_prob_model_with_pea.ipynb

Note that this is a PR to merge into the dark-model-acq-model (PR #37) branch.  Most likely it won't go into flight in this form but it work for now for analysis.

cc: @mbaski @jeanconn 