### PR TITLE
Bugfix: Update test_halfwidth_adjustment to use fixed date 

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .transform import *
 
-__version__ = '3.16.2'
+__version__ = '3.16.3'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -25,10 +25,12 @@ def test_mag_for_p_acq():
 def test_halfwidth_adjustment():
     mag = 10.3
     halfwidth = [40, 80, 120, 180, 240]
-    p120 = acq_success_prob(mag=mag, halfwidth=120)
-    pacq = acq_success_prob(mag=mag, halfwidth=halfwidth)
+    p120 = acq_success_prob(mag=mag, date='2018:001', halfwidth=120)
+    pacq = acq_success_prob(mag=mag, date='2018:001', halfwidth=halfwidth)
     mults = pacq / p120
-    assert np.allclose(mults, [1.07144731, 1.04454684, 1., 0.9139956, 0.83812176])
+    assert np.allclose(mults, [1.07260318, 1.04512285,  1., 0.91312975, 0.83667405])
+
+
 
 
 def test_acq_success_prob_date():


### PR DESCRIPTION
Update the test to use a fixed date in acq_success_prob so that the ratios remain fixed (and the new regress values stay correct).  We could alternatively test using a larger tolerance as the ratios shouldn't change much.