### PR TITLE
Implement data model numerical operators using ACA coordinates

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -38,13 +38,13 @@ def _operator_factory(operator, inplace=False):
     def _operator(self, other):
 
         if isinstance(other, ACAImage) and (other._aca_coords or self._aca_coords):
+            # If inplace then work on the original self, else use a copy
             out = self if inplace else self.copy()
 
-            # True for expressions like img1.aca + img2.aca
             sz_r0, sz_c0 = self.shape
             sz_r1, sz_c1 = other.shape
 
-            # If images overlap
+            # If images overlap do this process, else return unmodified ``out``.
             if all(diff > 0 for diff in [self.row0 + sz_r0 - other.row0,
                                          self.col0 + sz_c0 - other.col0,
                                          other.row0 + sz_r1 - self.row0,
@@ -62,6 +62,8 @@ def _operator_factory(operator, inplace=False):
                 sz_c = c_max - c_min
                 section = ACAImage(shape=(sz_r, sz_c), row0=row0, col0=col0)
 
+                # Always use the inplace operator, but remember that ``out`` is a copy of
+                # self for inplace=False (thus mimicking the non-inplace version).
                 inplace_op(out[section], other.view(np.ndarray)[r_min:r_max, c_min:c_max])
 
         else:

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -23,6 +23,48 @@ Pixel A1 has the lowest values of row and column; pixel H1 has the lowest
 row and highest col; pixel I4 has the highest row and lowest column."""
 
 
+def _operator_factory(operator, inplace=False):
+    """
+    Generate data model methods like __add__(self, other) and
+    __iadd__(self, other).  These always operate in ACA coordinates
+    and any non-overlapping pixels are ignored.
+    """
+    op = getattr(np.ndarray, '__{}__'.format(operator))
+    iop = op if inplace else getattr(np.ndarray, '__i{}__'.format(operator))
+
+    def _operator(self, other):
+        if not isinstance(other, ACAImage):
+            out = op(self, other)  # returns self for inplace ops
+
+        else:
+            sz_r0, sz_c0 = self.shape
+            sz_r1, sz_c1 = other.shape
+
+            # If images overlap
+            if all(diff > 0 for diff in [self.row0 + sz_r0 - other.row0,
+                                         self.col0 + sz_c0 - other.col0,
+                                         other.row0 + sz_r1 - self.row0,
+                                         other.col0 + sz_c1 - self.col0]):
+
+                dr = other.row0 - self.row0
+                dc = other.col0 - self.col0
+
+                r_min, r_max = -min(0, dr), min(sz_r1, sz_r0 - dr)
+                c_min, c_max = -min(0, dc), min(sz_c1, sz_c0 - dc)
+
+                row0 = max(self.row0, other.row0)
+                col0 = max(self.col0, other.col0)
+                sz_r = r_max - r_min
+                sz_c = c_max - c_min
+                section = ACAImage(shape=(sz_r, sz_c), row0=row0, col0=col0)
+
+                out = self if inplace else self.copy()
+                iop(out[section], other[r_min:r_max, c_min:c_max])
+
+        return out
+    return _operator
+
+
 class ACAImage(np.ndarray):
     """
     ACAImage is an ndarray subclass that supports functionality for the Chandra
@@ -105,6 +147,24 @@ class ACAImage(np.ndarray):
 
         self.meta = deepcopy(getattr(obj, 'meta', {}))
         self._aca_coords = getattr(obj, '_aca_coords', False)
+
+    __add__ = _operator_factory('add')
+    __sub__ = _operator_factory('sub')
+    __mul__ = _operator_factory('mul')
+    __div__ = _operator_factory('div')
+    __truediv__ = _operator_factory('truediv')
+    __floordiv__ = _operator_factory('floordiv')
+    __mod__ = _operator_factory('mod')
+    __pow__ = _operator_factory('pow')
+
+    __iadd__ = _operator_factory('iadd', inplace=True)
+    __isub__ = _operator_factory('isub', inplace=True)
+    __imul__ = _operator_factory('imul', inplace=True)
+    __idiv__ = _operator_factory('idiv', inplace=True)
+    __itruediv__ = _operator_factory('itruediv', inplace=True)
+    __ifloordiv__ = _operator_factory('ifloordiv', inplace=True)
+    __imod__ = _operator_factory('imod', inplace=True)
+    __ipow__ = _operator_factory('ipow', inplace=True)
 
     def _adjust_item(self, item):
         """

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -237,3 +237,30 @@ def test_aca_image_fm_centroid(aca):
                                                            norm_clip=1.0)
     assert np.isclose(row, -9379.5 + (row0 if aca else 0))
     assert np.isclose(col, -9379.5 + (col0 if aca else 0))
+
+
+def test_aca_image_operators():
+    row0 = 10
+    col0 = 20
+    a = ACAImage(shape=(4, 4), row0=row0, col0=col0) + 2
+    b = ACAImage(np.arange(1, 17).reshape(4, 4), row0=row0-2, col0=col0-1) * 10
+    ab = [[12, 22, 32, 42],
+          [52, 62, 72, 82],
+          [92, 102, 112, 122],
+          [132, 142, 152, 162]]
+    assert np.all(a + b == ab)
+
+    ab_aca = [[102, 112, 122, 2],
+              [142, 152, 162, 2],
+              [2, 2, 2, 2],
+              [2, 2, 2, 2]]
+    assert np.all(a + b.aca == ab_aca)
+    assert np.all(a.aca + b == ab_aca)
+    assert np.all(a.aca + b.aca == ab_aca)
+
+    b = ACAImage(np.arange(1, 17).reshape(4, 4), row0=row0+2, col0=col0-2) * 10
+
+    assert np.all(a + b.aca == [[2, 2, 2, 2],
+                                [2, 2, 2, 2],
+                                [32, 42, 2, 2],
+                                [72, 82, 2, 2]])

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -242,14 +242,32 @@ def test_aca_image_fm_centroid(aca):
 def test_aca_image_operators():
     row0 = 10
     col0 = 20
+
+    # Test case of adding in native (non-ACA) coordinates.  Just like normal
+    # numpy array add.
     a = ACAImage(shape=(4, 4), row0=row0, col0=col0) + 2
     b = ACAImage(np.arange(1, 17).reshape(4, 4), row0=row0-2, col0=col0-1) * 10
+    # In [8]: a
+    # <ACAImage row0=10 col0=10
+    # array([[2, 2, 2, 2],
+    #        [2, 2, 2, 2],
+    #        [2, 2, 2, 2],
+    #        [2, 2, 2, 2]])>
+
+    # In [9]: b
+    # <ACAImage row0=8 col0=9
+    # array([[ 10,  20,  30,  40],
+    #        [ 50,  60,  70,  80],
+    #        [ 90, 100, 110, 120],
+    #        [130, 140, 150, 160]])>
+
     ab = [[12, 22, 32, 42],
           [52, 62, 72, 82],
           [92, 102, 112, 122],
           [132, 142, 152, 162]]
     assert np.all(a + b == ab)
 
+    # Now test adding in ACA coordinates with partially overlapping images.
     ab_aca = [[102, 112, 122, 2],
               [142, 152, 162, 2],
               [2, 2, 2, 2],
@@ -258,9 +276,52 @@ def test_aca_image_operators():
     assert np.all(a.aca + b == ab_aca)
     assert np.all(a.aca + b.aca == ab_aca)
 
+    # Inplace operations.  Note that a.aca += <anything> does not work because
+    # that is trying to update the attribute instead of the returned object.
+    a = ACAImage(shape=(4, 4), row0=row0, col0=col0) + 2
+    a += b
+    assert np.all(a == ab)
+
+    a = ACAImage(shape=(4, 4), row0=row0, col0=col0) + 2
+    a += b.aca
+    assert np.all(a == ab_aca)
+
+    # Test for one image fully enclosed in the other
+    a = ACAImage(shape=(4, 4), row0=row0, col0=col0) + 2
     b = ACAImage(np.arange(1, 17).reshape(4, 4), row0=row0+2, col0=col0-2) * 10
 
     assert np.all(a + b.aca == [[2, 2, 2, 2],
                                 [2, 2, 2, 2],
                                 [32, 42, 2, 2],
                                 [72, 82, 2, 2]])
+
+    a = ACAImage(np.arange(16).reshape(4, 4), row0=row0, col0=col0) + 2
+    b = ACAImage([[100, 200], [300, 400]], row0=row0+1, col0=col0+1)
+
+    # Shape mismatch
+    with pytest.raises(ValueError):
+        a + b
+
+    # right side is enclosed within left side
+    out = a + b.aca
+    assert np.all(out == [[2, 3, 4, 5],
+                          [6, 107, 208, 9],
+                          [10, 311, 412, 13],
+                          [14, 15, 16, 17]])
+
+    assert out.row0 == 10
+    assert out.col0 == 20
+
+    # right side is a superset of left side
+    out = b + a.aca
+    assert np.all(out == [[107, 208],
+                          [311, 412]])
+    assert out.row0 == 11
+    assert out.col0 == 21
+
+    # Subtraction
+    out = a - b.aca
+    assert np.all(out == [[2, 3, 4, 5],
+                          [6, -93, -192, 9],
+                          [10, -289, -388, 13],
+                          [14, 15, 16, 17]])


### PR DESCRIPTION
This requires opt-in by only doing this if one of the operands is in ACA coords, i.e. `a.aca + b` or `a + b.aca` or `a.aca + b.aca`.
```
**Initialize images (different shape and offset)**

  >>> from chandra_aca.aca_image import *
  >>> a = ACAImage(shape=(6, 6), row0=10, col0=20) + 1
  >>> a
  <ACAImage row0=10 col0=20
  array([[1, 1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1, 1],
         [1, 1, 1, 1, 1, 1]])>
  >>> b = ACAImage(np.arange(1, 17).reshape(4, 4), row0=8, col0=18) * 10
  >>> b
  <ACAImage row0=8 col0=18
  array([[ 10,  20,  30,  40],
         [ 50,  60,  70,  80],
         [ 90, 100, 110, 120],
         [130, 140, 150, 160]])>

**Add images (output has shape and row0/col0 of left side input)**

  >>> a + b.aca
  <ACAImage row0=10 col0=20
  array([[111, 121,   1,   1,   1,   1],
         [151, 161,   1,   1,   1,   1],
         [  1,   1,   1,   1,   1,   1],
         [  1,   1,   1,   1,   1,   1],
         [  1,   1,   1,   1,   1,   1],
         [  1,   1,   1,   1,   1,   1]])>
  >>> b + a.aca
  <ACAImage row0=8 col0=18
  array([[ 10,  20,  30,  40],
         [ 50,  60,  70,  80],
         [ 90, 100, 111, 121],
         [130, 140, 151, 161]])>

  >>> b += a.aca
  >>> b
  <ACAImage row0=8 col0=18
  array([[ 10,  20,  30,  40],
         [ 50,  60,  70,  80],
         [ 90, 100, 111, 121],
         [130, 140, 151, 161]])>

**Make ``b`` image be fully contained in ``a``**

  >>> b.row0 = 11
  >>> b.col0 = 21
  >>> a += b.aca
  >>> a
  <ACAImage row0=10 col0=20
  array([[  1,   1,   1,   1,   1,   1],
         [  1,  11,  21,  31,  41,   1],
         [  1,  51,  61,  71,  81,   1],
         [  1,  91, 101, 112, 122,   1],
         [  1, 131, 141, 152, 162,   1],
         [  1,   1,   1,   1,   1,   1]])>
```
