### PR TITLE
 Do not create __div__ method in py3

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .transform import *
 
-__version__ = '3.18'
+__version__ = '3.18.1'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -3,6 +3,8 @@ import os
 from math import floor
 from itertools import count, chain
 from copy import deepcopy
+
+import six
 from six.moves import zip
 
 import numpy as np
@@ -159,7 +161,8 @@ class ACAImage(np.ndarray):
     __add__ = _operator_factory('add')
     __sub__ = _operator_factory('sub')
     __mul__ = _operator_factory('mul')
-    __div__ = _operator_factory('div')
+    if not six.PY3:
+        __div__ = _operator_factory('div')
     __truediv__ = _operator_factory('truediv')
     __floordiv__ = _operator_factory('floordiv')
     __mod__ = _operator_factory('mod')
@@ -168,7 +171,8 @@ class ACAImage(np.ndarray):
     __iadd__ = _operator_factory('iadd', inplace=True)
     __isub__ = _operator_factory('isub', inplace=True)
     __imul__ = _operator_factory('imul', inplace=True)
-    __idiv__ = _operator_factory('idiv', inplace=True)
+    if not six.PY3:
+        __idiv__ = _operator_factory('idiv', inplace=True)
     __itruediv__ = _operator_factory('itruediv', inplace=True)
     __ifloordiv__ = _operator_factory('ifloordiv', inplace=True)
     __imod__ = _operator_factory('imod', inplace=True)

--- a/chandra_aca/tests/test_psf.py
+++ b/chandra_aca/tests/test_psf.py
@@ -57,7 +57,7 @@ def test_psf_at_index_location():
     ii = 2
     jj = 3
     ok = (dat['row_bin_idx'] == ii) & (dat['col_bin_idx'] == jj)
-    i22 = np.flatnonzero(ok)
+    i22 = np.flatnonzero(ok)[0]
     row = dat[i22]
 
     # Row/col of center of bin


### PR DESCRIPTION
There was also a test that was accidentally passing in Py2 because the built-in round function was trying to be too helpful and converting an astropy Column of length 1 to a scalar.