### PR TITLE
Add get_psf_image options for performance-critical applications

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -424,7 +424,8 @@ class AcaPsfLibrary(object):
 
         self.psfs = psfs
 
-    def get_psf_image(self, row, col, norm=1.0, pix_zero_loc='center'):
+    def get_psf_image(self, row, col, norm=1.0, pix_zero_loc='center',
+                      interpolation='bilinear', aca_image=True):
         """
         Get interpolated ACA PSF image that corresponds to pixel location
         ``row``, ``col``.
@@ -433,6 +434,8 @@ class AcaPsfLibrary(object):
         :param col: (float) col value of PSF centroid
         :param norm: (float) summed intensity of PSF image
         :param pix_zero_loc: row/col coords are integral at 'edge' or 'center'
+        :param interpolation: 'nearest' | 'bilinear' (default)
+        :param aca_image: return ACAImage if True, else return ndarray
 
         :returns: 8x8 PSF image normalized to 1.0 (AcaImage object)
         """
@@ -460,30 +463,43 @@ class AcaPsfLibrary(object):
         ix = (r + 0.5) / drc - 0.5
         iy = (c + 0.5) / drc - 0.5
 
-        # Int index into PSF library
-        ii = int(floor(ix))
-        jj = int(floor(iy))
+        if interpolation == 'nearest':
+            # Int index into PSF library
+            ii = int(round(ix))
+            jj = int(round(iy))
+            psf = self.psfs[ii, jj].copy()
 
-        # Following wikipedia notation (Unit Square section of
-        # https://en.wikipedia.org/wiki/Bilinear_interpolation)
+        elif interpolation == 'bilinear':
+            # Int index into PSF library
+            ii = int(floor(ix))
+            jj = int(floor(iy))
 
-        # Float index within subpixel bin in range (0, 1)
-        x = ix - ii
-        y = iy - jj
+            # Following wikipedia notation (Unit Square section of
+            # https://en.wikipedia.org/wiki/Bilinear_interpolation)
 
-        # Finally the bilinear interpolation of the PSF images.
-        f = self.psfs
-        b0 = (1 - x) * (1 - y)
-        b1 = x * (1 - y)
-        b2 = (1 - x) * y
-        b3 = x * y
-        P0 = f[ii, jj]
-        P1 = f[ii + 1, jj]
-        P2 = f[ii, jj + 1]
-        P3 = f[ii + 1, jj + 1]
-        psf = P0 * b0 + P1 * b1 + P2 * b2 + P3 * b3
+            # Float index within subpixel bin in range (0, 1)
+            x = ix - ii
+            y = iy - jj
+
+            # Finally the bilinear interpolation of the PSF images.
+            f = self.psfs
+            b0 = (1 - x) * (1 - y)
+            b1 = x * (1 - y)
+            b2 = (1 - x) * y
+            b3 = x * y
+            P0 = f[ii, jj]
+            P1 = f[ii + 1, jj]
+            P2 = f[ii, jj + 1]
+            P3 = f[ii + 1, jj + 1]
+            psf = P0 * b0 + P1 * b1 + P2 * b2 + P3 * b3
+
+        else:
+            raise ValueError("interpolation must be 'nearest' or 'bilinear'")
 
         if norm != 1.0:
             psf *= norm
 
-        return ACAImage(psf, row0=row0, col0=col0)
+        if aca_image:
+            psf = ACAImage(psf, row0=row0, col0=col0)
+
+        return psf

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -437,7 +437,7 @@ class AcaPsfLibrary(object):
         :param interpolation: 'nearest' | 'bilinear' (default)
         :param aca_image: return ACAImage if True, else return ndarray
 
-        :returns: 8x8 PSF image normalized to 1.0 (AcaImage object)
+        :returns: ACAImage if (aca_image is True) else (ndarray image, row0, col0)
         """
         drc = self.drc
 
@@ -451,8 +451,8 @@ class AcaPsfLibrary(object):
         # 8x8 image row0, col0
         round_row = round(row)
         round_col = round(col)
-        row0 = round_row - 4
-        col0 = round_col - 4
+        row0 = int(round_row) - 4
+        col0 = int(round_col) - 4
 
         # Subpixel position in range (-0.5, 0.5)
         r = row - round_row
@@ -499,7 +499,5 @@ class AcaPsfLibrary(object):
         if norm != 1.0:
             psf *= norm
 
-        if aca_image:
-            psf = ACAImage(psf, row0=row0, col0=col0)
-
-        return psf
+        out = ACAImage(psf, row0=row0, col0=col0) if aca_image else (psf, row0, col0)
+        return out

--- a/chandra_aca/tests/test_psf.py
+++ b/chandra_aca/tests/test_psf.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..aca_image import AcaPsfLibrary
+from ..aca_image import AcaPsfLibrary, ACAImage
 
 ap = AcaPsfLibrary()
 
@@ -8,7 +8,11 @@ def test_basic():
     assert len(ap.psfs) == 12 ** 2
     assert np.isclose(ap.drc, 0.1, rtol=0, atol=1e-8)  # Current PSF library has 0.1 pixel gridding
     psf = ap.get_psf_image(0, 0)
-    assert psf.__class__.__name__ == 'ACAImage'
+    assert isinstance(psf, ACAImage)
+
+    psf = ap.get_psf_image(0, 0, aca_image=False)
+    assert not isinstance(psf, ACAImage)
+    assert isinstance(psf, np.ndarray)
 
 
 def test_centroids():
@@ -65,6 +69,16 @@ def test_psf_at_index_location():
     cc = (row['col_bin_left_edge'] + row['col_bin_right_edge']) / 2.0
 
     psf_direct = ap.psfs[ii, jj]
-    psf_interp = ap.get_psf_image(rc, cc, pix_zero_loc='edge')
 
+    psf_interp = ap.get_psf_image(rc, cc, pix_zero_loc='edge')
+    assert np.allclose(psf_direct, psf_interp, rtol=0, atol=1e-5)
+
+    # Test with interpolation=nearest
+    psf_interp = ap.get_psf_image(rc, cc, pix_zero_loc='edge', interpolation='nearest')
+    assert np.allclose(psf_direct, psf_interp, rtol=0, atol=1e-5)
+
+    # Test with interpolation=nearest, slightly offset but still within grid subpixel
+    psf_interp = ap.get_psf_image(rc + ap.drc * 0.45, cc - ap.drc * 0.45,
+                                  pix_zero_loc='edge',
+                                  interpolation='nearest')
     assert np.allclose(psf_direct, psf_interp, rtol=0, atol=1e-5)

--- a/chandra_aca/tests/test_psf.py
+++ b/chandra_aca/tests/test_psf.py
@@ -10,9 +10,12 @@ def test_basic():
     psf = ap.get_psf_image(0, 0)
     assert isinstance(psf, ACAImage)
 
-    psf = ap.get_psf_image(0, 0, aca_image=False)
+    psf, row0, col0 = ap.get_psf_image(104.1, 203.9, aca_image=False,
+                                       pix_zero_loc='edge')
     assert not isinstance(psf, ACAImage)
     assert isinstance(psf, np.ndarray)
+    assert row0 == 100
+    assert col0 == 200
 
 
 def test_centroids():


### PR DESCRIPTION
These two options allow `get_psf_image` to run faster:
```
In [1]: from chandra_aca.aca_image import AcaPsfLibrary

In [2]: ap = AcaPsfLibrary()

In [3]: timeit ap.get_psf_image(100.05, 200.05)
82.7 µs ± 4.45 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: timeit ap.get_psf_image(100.05, 200.05, aca_image=False)
37 µs ± 158 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: timeit ap.get_psf_image(100.05, 200.05, aca_image=False, interpolation='nearest')
18.6 µs ± 100 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
If or when we put this into starcheck or star selection then a factor of 4 (plus downstream speedup by using `ndarray` instead of `ACAImage`) will be important.  There is also potential for numba-izing this, though at 18 usec this part might no longer be the bottleneck.