### PR TITLE
Use isclose to match star colors against 1.5 or 0.7

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .transform import *
 
-__version__ = '3.18.1'
+__version__ = '3.18.2'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -257,7 +257,7 @@ def acq_success_prob(date=None, t_ccd=-19.0, mag=10.0, color=0.6, spoiler=False,
     # If the star is brighter than 8.5 or has a calculated probability
     # higher than the max_star_prob, clip it at that value
     probs[mags < 8.5] = MAX_ACQ_PROB
-    probs[colors == 0.7] *= p_0p7color
+    probs[np.isclose(colors, 0.7, atol=1e-6, rtol=0)] *= p_0p7color
     probs[spoilers] *= p_spoiler
 
     probs = probs.clip(MIN_ACQ_PROB, MAX_ACQ_PROB)

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -300,8 +300,9 @@ def model_acq_success_prob(mag, warm_frac, color=0, halfwidth=120):
     box120 = (halfwidth - 120) / 120  # Normalized halfwidth, 0.0 for halfwidth=120
 
     p_fail = np.zeros_like(mag)
-    for mask, fit_pars in ((color == 1.5, SOTA_FIT_ONLY_1P5),
-                           (color != 1.5, SOTA_FIT_NO_1P5)):
+    color1p5 = np.isclose(color, 1.5, atol=1e-6, rtol=0)
+    for mask, fit_pars in ((color1p5, SOTA_FIT_ONLY_1P5),
+                           (~color1p5, SOTA_FIT_NO_1P5)):
         if np.any(mask):
             scale = np.polyval(fit_pars[0:3][::-1], m10)
             offset = np.polyval(fit_pars[3:6][::-1], m10)

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -58,7 +58,8 @@ def test_acq_success_prob_spoiler():
 
 def test_acq_success_prob_color():
     p_0p7color = .4294  # probability multiplier for a B-V = 0.700 star (REF?)
-    color = [0.6, 0.7, 1.5]
+    color = [0.6, 0.699997, 0.69999999, 0.7, 0.700001, 1.5]
     probs = acq_success_prob(date='2017:001', t_ccd=-10, mag=10.3, spoiler=False, color=color)
-    assert np.allclose(probs, [ 0.68643974,  0.29475723,  0.29295036])
-    assert np.allclose(p_0p7color, probs[1] / probs[0])
+    assert np.allclose(probs, [ 0.68643974, 0.68643974, 0.29475723, 0.29475723, 0.68643974, 0.29295036])
+    assert np.allclose(p_0p7color, probs[2] / probs[0])
+    assert np.allclose(p_0p7color, probs[3] / probs[0])

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -58,8 +58,9 @@ def test_acq_success_prob_spoiler():
 
 def test_acq_success_prob_color():
     p_0p7color = .4294  # probability multiplier for a B-V = 0.700 star (REF?)
-    color = [0.6, 0.699997, 0.69999999, 0.7, 0.700001, 1.5]
+    color = [0.6, 0.699997, 0.69999999, 0.7, 0.700001, 1.5, 1.49999999]
     probs = acq_success_prob(date='2017:001', t_ccd=-10, mag=10.3, spoiler=False, color=color)
-    assert np.allclose(probs, [ 0.68643974, 0.68643974, 0.29475723, 0.29475723, 0.68643974, 0.29295036])
+    assert np.allclose(probs, [ 0.68643974, 0.68643974, 0.29475723, 0.29475723, 0.68643974,
+                                0.29295036, 0.29295036])
     assert np.allclose(p_0p7color, probs[2] / probs[0])
     assert np.allclose(p_0p7color, probs[3] / probs[0])


### PR DESCRIPTION
Use isclose to match star colors really close to 0.700 as bad color and close to 1.5 as requiring the 1p5 model.

Closes #50 