### PR TITLE
Cast input y z in poly_convert to np.float64 to avoid overflows

### DIFF
--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -60,6 +60,13 @@ def test_angle_to_pix():
     np.testing.assert_allclose(angle_to_pix['col'], pycol, atol=TOLERANCE, rtol=0)
 
 
+def test_angle_to_pix_types():
+    for ftype in [int, float, np.int32, np.int64, np.float32]:
+        pyrow, pycol = chandra_aca.yagzag_to_pixels(ftype(2540), ftype(1660))
+        assert np.isclose(pyrow, -506.71, rtol=0, atol=0.01)
+        assert np.isclose(pycol, 341.19, rtol=0, atol=0.01)
+
+
 def test_pix_zero_loc():
     r, c = 100, 200
     ye, ze = chandra_aca.pixels_to_yagzag(r, c, pix_zero_loc='edge')

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -161,6 +161,11 @@ def yagzag_to_pixels(yang, zang, allow_bad=False, pix_zero_loc='edge'):
 
 
 def _poly_convert(y, z, coeffs, t_aca=None):
+
+    # Convert to avoid overflow errors with the polys on int32
+    y = np.asarray(y, dtype=np.float64)
+    z = np.asarray(z, dtype=np.float64)
+
     if y.size != z.size:
         raise ValueError("Mismatched number of Y/Z coords")
 


### PR DESCRIPTION
Cast everything to float64 to avoid RuntimeWarning overflows

Closes #61 