### PR TITLE
Update drift module parameters to the 2018-11 drift model

### DIFF
--- a/chandra_aca/__init__.py
+++ b/chandra_aca/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .transform import *
 
-__version__ = '4.23.1'
+__version__ = '4.24'
 
 
 def test(*args, **kwargs):

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -6,7 +6,7 @@ In particular compute the dynamical pointing offset required to achieve
 a desired zero-offset target aimpoint.
 
 A key element of this module is the fitting analysis here:
-https://github.com/sot/aimpoint_mon/blob/master/fit_aimpoint_drift.ipynb
+https://github.com/sot/aimpoint_mon/blob/master/fit_aimpoint_drift-2018-11.ipynb
 """
 
 from Chandra.Time import DateTime
@@ -14,23 +14,27 @@ from astropy.table import Table
 import numpy as np
 
 # Capture best fit model parameters for ACA drift model.
-# https://github.com/sot/aimpoint_mon/blob/8259a23/fit_aimpoint_drift.ipynb
+# https://github.com/sot/aimpoint_mon/blob/7809b89/fit_aimpoint_drift.ipynb
 # These are used below to instantiate corresponding AcaDriftModel objects.
 
-DRIFT_Y_PARS = dict(scale=2.183,  # drift per degF (NOT degC as elsewhere in this module)
-                    offset=-5.606,
-                    trend=-1.363,
-                    jumps=(('2015:006', -4.234),
-                           ('2015:265', -4.571),
-                           ('2016:064', -2.027)),
+DRIFT_Y_PARS = dict(scale=2.1467,  # drift per degF (NOT degC as elsewhere in this module)
+                    offset=-6.012,
+                    trend=-1.108,
+                    jumps=(('2015:006', -4.600),
+                           ('2015:265', -4.669),
+                           ('2016:064', -1.793),
+                           ('2017:066', -1.725),
+                           ('2018:285', -12.505)),
                     year0=2016.0)
 
-DRIFT_Z_PARS = dict(scale=1.067,
-                    offset=-14.374,
-                    trend=-0.407,
-                    jumps=(('2015:006', -1.8154),
-                           ('2015:265', -0.3033),
-                           ('2016:064', -1.1105)),
+DRIFT_Z_PARS = dict(scale=1.004,
+                    offset=-15.963,
+                    trend=-0.159,
+                    jumps=(('2015:006', -2.109),
+                           ('2015:265', -0.368),
+                           ('2016:064', -0.902),
+                           ('2017:066', -0.856),
+                           ('2018:285', -6.056)),
                     year0=2016.0)
 
 # Define transform from aspect solution DY, DZ (mm) to CHIPX, CHIPY for

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -145,12 +145,12 @@ def simple_test_aca_drift():
     """
     Qualitatively test the implementation of drift model by plotting (outside
     of this function) the returned drift values and comparing with plots in
-    https://github.com/sot/aimpoint_mon/blob/master/fit_aimpoint_drift.ipynb
+    https://github.com/sot/aimpoint_mon/blob/master/fit_aimpoint_drift-2018-11.ipynb
 
     Match: YES.
     """
-    times = DateTime(np.arange(2013.0, 2016.5, 0.01), format='frac_year').secs
-    t_ccd = -13.8888889 * np.ones_like(times)  # degC, equivalent to +7.0 degC
+    times = DateTime(np.arange(2013.0, 2019.0, 0.01), format='frac_year').secs
+    t_ccd = -10.0 * np.ones_like(times)  # degC
     dy = drift.DRIFT_Y.calc(times, t_ccd)
     dz = drift.DRIFT_Z.calc(times, t_ccd)
 
@@ -166,16 +166,16 @@ def test_get_aca_offsets():
     given inputs.
     """
     offsets = drift.get_aca_offsets('ACIS-I', 3, 930.2, 1009.6, '2016:180', -15.0)
-    assert np.allclose(offsets, (11.83637884563926, 2.6860740140775334), atol=0.1, rtol=0)
+    assert np.allclose(offsets, (11.45, 2.34), atol=0.1, rtol=0)
 
     offsets = drift.get_aca_offsets('ACIS-S', 7, 200.7, 476.9, '2016:180', -15.0)
-    assert np.allclose(offsets, (13.360706170615167, 3.8670874955935481), atol=0.1, rtol=0)
+    assert np.allclose(offsets, (12.98, 3.52), atol=0.1, rtol=0)
 
     offsets = drift.get_aca_offsets('HRC-I', 0, 7591, 7936, '2016:180', -15.0)
-    assert np.allclose(offsets, (14.728718419826098, 0.7925650626134555), atol=0.1, rtol=0)
+    assert np.allclose(offsets, (14.35, 0.45), atol=0.1, rtol=0)
 
     offsets = drift.get_aca_offsets('HRC-S', 2, 2041, 9062, '2016:180', -15.0)
-    assert np.allclose(offsets, (17.269560057119545, 3.4474216529603225), atol=0.1, rtol=0)
+    assert np.allclose(offsets, (16.89, 3.10), atol=0.1, rtol=0)
 
 
 def test_snr_mag():


### PR DESCRIPTION
Based on the notebook in https://github.com/sot/aimpoint_mon/pull/17.   This notebook contains validation of the `chandra_aca.drift` update.

NOTE: commit 53fd2e3 will be back-ported to the `ska-legacy` branch.  All validation testing and model development was done using Ska2.  This PR also passes unit tests in Ska3 flight.

Reviewed and approved by SSAWG 2018-11-07.