### PR TITLE
Infrastructure improvements to transform module

### DIFF
--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 
 import os
 
+import pytest
 import numpy as np
 from astropy.io import ascii
 from astropy.table import Table
@@ -87,6 +88,33 @@ def test_pix_zero_loc():
     assert np.isclose(rc - r, 0, rtol=0, atol=0.01)
     assert np.isclose(ce - c, 0, rtol=0, atol=0.01)
     assert np.isclose(cc - c, 0, rtol=0, atol=0.01)
+
+
+@pytest.mark.parametrize('func', [chandra_aca.pixels_to_yagzag,
+                                  chandra_aca.yagzag_to_pixels])
+def test_transform_broadcast(func):
+    rows = [-100, 100]
+    cols = [-200, 200]
+
+    # Transform 2-d array
+    r, c = np.meshgrid(rows, cols)
+    y, z = func(r, c)
+
+    # Transform flattened version of 2-d array
+    yf, zf = func(r.flatten(), c.flatten())
+
+    # Flattened output must be same as transform of flattened input
+    assert np.all(y.flatten() == yf)
+    assert np.all(z.flatten() == zf)
+
+    # Make sure scalars result in scalars
+    y, z = func(100, 200)
+    assert y.shape == ()
+    assert z.shape == ()
+    assert isinstance(y, np.float64)
+    assert isinstance(z, np.float64)
+    assert not isinstance(y, np.ndarray)
+    assert not isinstance(z, np.ndarray)
 
 
 def test_radec_to_yagzag():

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -12,7 +12,8 @@ from Chandra.Time import DateTime
 
 import chandra_aca
 from chandra_aca.star_probs import t_ccd_warm_limit, mag_for_p_acq, acq_success_prob
-from chandra_aca.transform import snr_mag_for_t_ccd
+from chandra_aca.transform import (snr_mag_for_t_ccd, radec_to_yagzag,
+                                   yagzag_to_radec)
 from chandra_aca import drift
 
 dirname = os.path.dirname(__file__)
@@ -86,6 +87,22 @@ def test_pix_zero_loc():
     assert np.isclose(rc - r, 0, rtol=0, atol=0.01)
     assert np.isclose(ce - c, 0, rtol=0, atol=0.01)
     assert np.isclose(cc - c, 0, rtol=0, atol=0.01)
+
+
+def test_radec_to_yagzag():
+    ra = 0.5
+    dec = 0.75
+    q_att = Quat([0, 0, 0])
+    yag, zag = radec_to_yagzag(ra, dec, q_att)
+    assert np.allclose([yag, zag], [1800.00, 2700.10], rtol=0, atol=0.01)
+
+
+def test_yagzag_to_radec():
+    yag = 1800.00
+    zag = 2700.10
+    q_att = Quat([0, 0, 0])
+    ra, dec = yagzag_to_radec(yag, zag, q_att)
+    assert np.allclose([ra, dec], [0.50, 0.75], rtol=0, atol=0.00001)
 
 
 def test_aca_targ_transforms():

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -228,6 +228,50 @@ def _poly_convert(y, z, coeffs, t_aca=None):
     return newy, newz
 
 
+def radec_to_yagzag(ra, dec, q_att):
+    """
+    Given RA, Dec, and pointing quaternion, determine ACA Y-ang, Z-ang.  The
+    input ``ra`` and ``dec`` values can be 1-d arrays in which case the output
+    ``yag`` and ``zag`` will be corresponding arrays of the same length.
+
+    This is a wrapper around Ska.quatutil.radec2yagzag but uses arcsec instead
+    of deg for yag, zag.
+
+    :param ra: Right Ascension (degrees)
+    :param dec: Declination (degrees)
+    :param q_att: ACA pointing quaternion
+
+    :returns:  yag, zag (arcsec)
+    """
+    from Ska.quatutil import radec2yagzag
+    yag, zag = radec2yagzag(ra, dec, q_att)
+    yag *= 3600
+    zag *= 3600
+
+    return yag, zag
+
+
+def yagzag_to_radec(yag, zag, q_att):
+    """
+    Given ACA Y-ang, Z-ang and pointing quaternion determine RA, Dec. The
+    input ``yag`` and ``zag`` values can be 1-d arrays in which case the output
+    ``ra`` and ``dec`` will be corresponding arrays of the same length.
+
+    This is a wrapper around Ska.quatutil.yagzag2radec but uses arcsec instead
+    of deg for yag, zag.
+
+    :param yag: ACA Y angle (arcsec)
+    :param zag: ACA Z angle (arcsec)
+    :param q_att: ACA pointing quaternion
+
+    :returns: ra, dec (arcsec)
+    """
+    from Ska.quatutil import yagzag2radec
+    ra, dec = yagzag2radec(yag / 3600, zag / 3600, q_att)
+
+    return ra, dec
+
+
 def mag_to_count_rate(mag):
     """
     Convert ACA mag to count rate in e- / sec

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -99,14 +99,14 @@ def broadcast_arrays(*args):
 
 
 def broadcast_arrays_flatten(*args):
-    """
-    Broadcast *args inputs to same shape and then return that
-    shape and the flattened view of all the inputs.  This lets
-    intermediate code work on arrays that are the same-length
-    1-d array and then reshape the output at the end.
+    """Broadcast *args inputs to same shape and then return that shape and the
+    flattened view of all the inputs.  This lets intermediate code work on all
+    scalars or all arrays that are the same-length 1-d array and then reshape
+    the output at the end (if necessary).
 
     :param args: tuple of scalar / array inputs
     :returns: [shape, *flat_args]
+
     """
     is_scalar, *outs = broadcast_arrays(*args)
     if is_scalar:
@@ -205,6 +205,8 @@ def _poly_convert(y, z, coeffs, t_aca=None):
     if y.size != z.size:
         raise ValueError("Mismatched number of Y/Z coords")
 
+    shape, y, z = broadcast_arrays_flatten(y, z)
+
     if len(coeffs) == 10:
         # No temperature dependence
         yy = y * y
@@ -224,6 +226,9 @@ def _poly_convert(y, z, coeffs, t_aca=None):
 
     newy = np.sum(coeffs[:, 0] * poly.transpose(), axis=-1)
     newz = np.sum(coeffs[:, 1] * poly.transpose(), axis=-1)
+    if shape:
+        newy.shape = shape
+        newz.shape = shape
 
     return newy, newz
 

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -81,6 +81,42 @@ ODB_SI_ALIGN = np.array([[0.999999905689160, -0.000337419984089, -0.000273439987
                          [0.000273439987106, -0.000000046132060, 0.999999962615285]])
 
 
+def broadcast_arrays(*args):
+    """
+    Broadcast *args inputs to same shape and return an ``is_scalar`` flag and
+    the broadcasted version of inputs.  This lets intermediate code work on
+    arrays that are guaranteed to be the same shape and at least a 1-d array,
+    but reshape the output at the end.
+
+    :param args: tuple of scalar / array inputs
+    :returns: [is_scalar, *flat_args]
+
+    """
+    is_scalar = all(np.array(arg).ndim == 0 for arg in args)
+    args = np.atleast_1d(*args)
+    outs = [is_scalar] + np.broadcast_arrays(*args)
+    return outs
+
+
+def broadcast_arrays_flatten(*args):
+    """
+    Broadcast *args inputs to same shape and then return that
+    shape and the flattened view of all the inputs.  This lets
+    intermediate code work on arrays that are the same-length
+    1-d array and then reshape the output at the end.
+
+    :param args: tuple of scalar / array inputs
+    :returns: [shape, *flat_args]
+    """
+    is_scalar, *outs = broadcast_arrays(*args)
+    if is_scalar:
+        return [()] + list(args)
+
+    shape = outs[0].shape
+    outs = [out.ravel() for out in outs]
+    return [shape] + outs
+
+
 def pixels_to_yagzag(row, col, allow_bad=False, flight=False, t_aca=20,
                      pix_zero_loc='edge'):
     """


### PR DESCRIPTION
### Add radec_to_yagzag and yagzag_to_radec

These are thin wrappers around the corresponding Ska.quatutil methods but use arcsec instead of deg for yag, zag.  They also get away from the deprecated `in2out` naming convention and put these functions where I would expect them to be.

### Fix bug in row/col <=> yag/zag transform for N-d input

For 2-d or greater inputs, yagzag_to_pixels or converse would get things wrong.

### Add broadcast_arrays_flatten(), broadcast_arrays() functions

Used in the above bug fix, but these are generally useful.