### PR TITLE
Fix bug in check of row/col off CCD

### DIFF
--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -14,7 +14,7 @@ from Chandra.Time import DateTime
 import chandra_aca
 from chandra_aca.star_probs import t_ccd_warm_limit, mag_for_p_acq, acq_success_prob
 from chandra_aca.transform import (snr_mag_for_t_ccd, radec_to_yagzag,
-                                   yagzag_to_radec)
+                                   yagzag_to_radec, pixels_to_yagzag, yagzag_to_pixels)
 from chandra_aca import drift
 
 dirname = os.path.dirname(__file__)
@@ -25,6 +25,24 @@ TOLERANCE = 0.05
 SI_ALIGN_CLASSIC = np.array([[1.0, 3.3742E-4, 2.7344E-4],
                              [-3.3742E-4, 1.0, 0.0],
                              [-2.7344E-4, 0.0, 1.0]]).transpose()
+
+
+def test_edge_checking():
+    """Test row/col edge checking"""
+
+    # Within limits, doesn't fail
+    yag, zag = pixels_to_yagzag(511.7, -511.7)
+    yagzag_to_pixels(yag, zag)
+
+    with pytest.raises(ValueError):
+        pixels_to_yagzag(512.2, 0)
+
+    with pytest.raises(ValueError):
+        pixels_to_yagzag(0, -512.2)
+
+    yag, zag = pixels_to_yagzag(512.2, -512.2, allow_bad=True)
+    with pytest.raises(ValueError):
+        yagzag_to_pixels(yag, zag)
 
 
 def test_pix_to_angle():

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -149,13 +149,16 @@ def pixels_to_yagzag(row, col, allow_bad=False, flight=False, t_aca=20,
     elif pix_zero_loc != 'edge':
         raise ValueError("pix_zero_loc can be only 'edge' or 'center'")
 
-    if (not allow_bad and
-        (np.any(row > 511.5) or np.any(row < -512.5) or
-         np.any(col > 511.5) or np.any(col < -512.5))):
+    # Row/col are in edge coordinates at this point, check if they are on
+    # the CCD unless allow_bad is True.
+    if (not allow_bad and (np.any(np.abs(row) > 512.0) or
+                           np.any(np.abs(col) > 512.0))):
         raise ValueError("Coordinate off CCD")
+
     coeff = PIX2ACA_eeprom if flight else PIX2ACA_coeff
     yrad, zrad = _poly_convert(row, col, coeff, t_aca)
-    # convert to arcsecs from radians
+
+    # Convert to arcsecs from radians
     return 3600 * np.degrees(yrad), 3600 * np.degrees(zrad)
 
 
@@ -180,9 +183,11 @@ def yagzag_to_pixels(yang, zang, allow_bad=False, pix_zero_loc='edge'):
     yang = np.array(yang)
     zang = np.array(zang)
     row, col = _poly_convert(yang, zang, ACA2PIX_coeff)
-    if (not allow_bad and
-        (np.any(row > 511.5) or np.any(row < -512.5) or
-         np.any(col > 511.5) or np.any(col < -512.5))):
+
+    # Row/col are in edge coordinates at this point, check if they are on
+    # the CCD unless allow_bad is True.
+    if (not allow_bad and (np.any(np.abs(row) > 512.0) or
+                           np.any(np.abs(col) > 512.0))):
         raise ValueError("Coordinate off CCD")
 
     if pix_zero_loc == 'center':


### PR DESCRIPTION
This came up in starcheck / proseco development.  See also row-col-zero-location.ipynb notebook in the proseco validation dir.