### PR TITLE
Restore guide_count to be closer to previous

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -683,7 +683,7 @@ def guide_count(mags, t_ccd, count_9th=False):
     """
     # Generate interpolation curve for the specified input ``t_ccd``
     ref_t_ccd = -10.9
-    ref_mags0 = (9.0 if count_9th else 10.0) + np.array([0.0, 0.2, 0.3, 0.4])
+    ref_mags0 = (9.0 if count_9th else 9.95) + np.array([0.0, 0.2, 0.3, 0.4])
     ref_mags_t_ccd = [snr_mag_for_t_ccd(t_ccd, ref_mag, ref_t_ccd) for ref_mag in ref_mags0]
 
     # The 5.85 and 5.95 limits are not temperature dependent, these reflect the

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -123,6 +123,8 @@ def test_guide_count(count_9th):
     if count_9th:
         # This corresponds to the effective mag adjustment for 9th mag counting
         mags[mags > 6.1] -= 1.0
+    else:
+        mags[mags > 6.1] -= 0.05
 
     for mag, exp in zip(mags, exps):
         cnt = guide_count([mag], t_ccd=-10.9, count_9th=count_9th)


### PR DESCRIPTION
I got cold feet at the new linear guide_count interpolation after seeing proseco unit tests fail and realizing we still have eggs in the `guide_count` basket for ACA review of guide catalogs.  Here is the new proposed line.  This is closer to splitting the difference in the previous step-wise version.

![image](https://user-images.githubusercontent.com/348089/52811528-55bf3280-3063-11e9-9f60-4cd6218a5ab2.png)
