### PR TITLE
Use repository_dispatch to trigger build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   release:
     types:
     - created
+  repository_dispatch:
+    types:
+    - conda-build
 
 jobs:
   build-linux:


### PR DESCRIPTION
added repository_dispatch as one of the possibilities for triggering build. This is a test that needs to be in master.

