### PR TITLE
Fixed bug in decom of imgstat. It must be an unsigned int.

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -284,7 +284,7 @@ class _AcaImageHeaderDecom:
             'IMGFID': bool(bits[0]),
             'IMGNUM': _packbits(bits[1:4]),
             'IMGFUNC': _packbits(bits[4:6]),
-            'IMGSTAT': _packbits(bits[6:12], unsigned=False),
+            'IMGSTAT': _packbits(bits[6:12]),
             'SAT_PIXEL': bool(bits[6]),
             'DEF_PIXEL': bool(bits[7]),
             'QUAD_BOUND': bool(bits[8]),


### PR DESCRIPTION
## Description

IMGSTAT is an unsigned 6-bit int, but the value is decom as a signed 6-bit int. This can produce negative numbers which, when cast into unsigned 32-bit int downstream, will produce numbers larger than 2^6.

## Testing

Tests passed because there is no test for this failure

- [x] Passes unit tests on MacOS
- [x] Functional testing
