### PR TITLE
Shiny tests

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,4 +18,4 @@ jobs:
         pip install flake8
         # Note: only check files in Ska.engarchive package.  Many other files in
         # the repo are not maintained as PEP8 compliant.
-        flake8 . --count --exclude=docs/conf.py --ignore=W504 --max-line-length=100 --show-source --statistics
+        flake8 . --count --exclude=docs/conf.py --ignore=W504,F541 --max-line-length=100 --show-source --statistics

--- a/chandra_aca/dark_model.py
+++ b/chandra_aca/dark_model.py
@@ -223,7 +223,7 @@ def get_sbp_pars(dates):
     return pars_list
 
 
-def get_warm_fracs(warm_threshold, date='2013:001', T_ccd=-19.0):
+def get_warm_fracs(warm_threshold, date='2013:001:12:00:00', T_ccd=-19.0):
     """
     Calculate fraction of pixels in modeled dark current distribution
     above warm threshold(s).
@@ -272,7 +272,7 @@ def synthetic_dark_image(date, t_ccd_ref=None):
     from mica.archive.aca_dark import get_dark_cal_image
 
     if 'dark_1999223' not in CACHE:
-        dark = get_dark_cal_image('1999:223', select='nearest', t_ccd_ref=-14).ravel()
+        dark = get_dark_cal_image('1999:223:12:00:00', select='nearest', t_ccd_ref=-14).ravel()
         CACHE['dark_1999223'] = dark.copy()
     else:
         dark = CACHE['dark_1999223'].copy()

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -20,21 +20,21 @@ import numpy as np
 DRIFT_Y_PARS = dict(scale=2.1467,  # drift per degF (NOT degC as elsewhere in this module)
                     offset=-6.012,
                     trend=-1.108,
-                    jumps=(('2015:006', -4.600),
-                           ('2015:265', -4.669),
-                           ('2016:064', -1.793),
-                           ('2017:066', -1.725),
-                           ('2018:285', -12.505)),
+                    jumps=(('2015:006:12:00:00', -4.600),
+                           ('2015:265:12:00:00', -4.669),
+                           ('2016:064:12:00:00', -1.793),
+                           ('2017:066:12:00:00', -1.725),
+                           ('2018:285:12:00:00', -12.505)),
                     year0=2016.0)
 
 DRIFT_Z_PARS = dict(scale=1.004,
                     offset=-15.963,
                     trend=-0.159,
-                    jumps=(('2015:006', -2.109),
-                           ('2015:265', -0.368),
-                           ('2016:064', -0.902),
-                           ('2017:066', -0.856),
-                           ('2018:285', -6.056)),
+                    jumps=(('2015:006:12:00:00', -2.109),
+                           ('2015:265:12:00:00', -0.368),
+                           ('2016:064:12:00:00', -0.902),
+                           ('2017:066:12:00:00', -0.856),
+                           ('2018:285:12:00:00', -6.056)),
                     year0=2016.0)
 
 # Define transform from aspect solution DY, DZ (mm) to CHIPX, CHIPY for
@@ -119,7 +119,7 @@ class AcaDriftModel(object):
         if np.any(np.diff(times) < 0):
             raise ValueError('times arg must be monotonically increasing')
 
-        if times[0] < DateTime('2012:001').secs:
+        if times[0] < DateTime('2012:001:12:00:00').secs:
             raise ValueError('model is not applicable before 2012')
 
         # Years from model `year0`

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -277,16 +277,16 @@ def test_get_aca_offsets():
     The output reference values here have been validated as being "reasonable" for the
     given inputs.
     """
-    offsets = drift.get_aca_offsets('ACIS-I', 3, 930.2, 1009.6, '2016:180', -15.0)
+    offsets = drift.get_aca_offsets('ACIS-I', 3, 930.2, 1009.6, '2016:180:12:00:00', -15.0)
     assert np.allclose(offsets, (11.45, 2.34), atol=0.1, rtol=0)
 
-    offsets = drift.get_aca_offsets('ACIS-S', 7, 200.7, 476.9, '2016:180', -15.0)
+    offsets = drift.get_aca_offsets('ACIS-S', 7, 200.7, 476.9, '2016:180:12:00:00', -15.0)
     assert np.allclose(offsets, (12.98, 3.52), atol=0.1, rtol=0)
 
-    offsets = drift.get_aca_offsets('HRC-I', 0, 7591, 7936, '2016:180', -15.0)
+    offsets = drift.get_aca_offsets('HRC-I', 0, 7591, 7936, '2016:180:12:00:00', -15.0)
     assert np.allclose(offsets, (14.35, 0.45), atol=0.1, rtol=0)
 
-    offsets = drift.get_aca_offsets('HRC-S', 2, 2041, 9062, '2016:180', -15.0)
+    offsets = drift.get_aca_offsets('HRC-S', 2, 2041, 9062, '2016:180:12:00:00', -15.0)
     assert np.allclose(offsets, (16.89, 3.10), atol=0.1, rtol=0)
 
 

--- a/chandra_aca/tests/test_dark_model.py
+++ b/chandra_aca/tests/test_dark_model.py
@@ -10,17 +10,17 @@ HAS_MICA = os.path.exists(MICA_ARCHIVE)
 
 
 def test_get_warm_fracs():
-    exp = {(100, '2020:001', -11): 294302,
-           (100, '2017:001', -11): 251865,
-           (100, '2020:001', -15): 215096,
-           (100, '2017:001', -15): 182365,
-           (1000, '2017:001', -11): 1296,
-           (1000, '2017:001', -15): 433,
-           (1000, '2020:001', -15): 500,
-           (1000, '2020:001', -11): 1536}
+    exp = {(100, '2020:001:12:00:00', -11): 294302,
+           (100, '2017:001:12:00:00', -11): 251865,
+           (100, '2020:001:12:00:00', -15): 215096,
+           (100, '2017:001:12:00:00', -15): 182365,
+           (1000, '2017:001:12:00:00', -11): 1296,
+           (1000, '2017:001:12:00:00', -15): 433,
+           (1000, '2020:001:12:00:00', -15): 500,
+           (1000, '2020:001:12:00:00', -11): 1536}
     warmpixs = {}
     for warm_threshold in (100, 1000):
-        for date in ('2017:001', '2020:001'):
+        for date in ('2017:001:12:00:00', '2020:001:12:00:00'):
             for T_ccd in (-11, -15):
                 key = (warm_threshold, date, T_ccd)
                 warmpixs[key] = int(get_warm_fracs(*key) * 1024 ** 2)
@@ -40,7 +40,7 @@ def test_dark_temp_scale():
 def test_synthetic_dark_image():
     """Predict 2017:185 dark cal"""
     np.random.seed(100)
-    dark = synthetic_dark_image('2017:010', t_ccd_ref=-13.55)
+    dark = synthetic_dark_image('2017:010:12:00:00', t_ccd_ref=-13.55)
     assert dark.shape == (1024, 1024)
 
     # Warm pixels above threshold
@@ -59,7 +59,7 @@ def test_synthetic_dark_image():
 
 def test_get_warm_fracs_2017185():
     """Predict 2017:185 dark cal"""
-    wfs = get_warm_fracs([100, 200, 1000, 2000, 3000], date='2017:010', T_ccd=-13.55)
+    wfs = get_warm_fracs([100, 200, 1000, 2000, 3000], date='2017:010:12:00:00', T_ccd=-13.55)
     wps = wfs * 1024 ** 2
 
     # Actual from 2017:185 dark cal at -13.55C : [218214, 83902, N/A, 88, 32]

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -142,12 +142,14 @@ def test_vcdu_vs_level0():
     table = maude_decom.get_aca_packets(start, stop, level0=True)
 
     table2 = maude_decom.get_aca_images(start, stop)
-    assert np.all(table == table2)
+    for col, col2 in zip(table.itercols(), table2.itercols()):
+        assert np.all(col == col2)
 
     raw = test_data[f'686111010-686111040']['raw']
     table2 = maude_decom._get_aca_packets(raw, start, stop,
                                           combine=True, adjust_time=True, calibrate=True)
-    assert np.all(table == table2)
+    for col, col2 in zip(table.itercols(), table2.itercols()):
+        assert np.all(col == col2)
 
     names = ['TIME', 'MJF', 'MNF', 'END_INTEG_TIME', 'INTEG', 'GLBSTAT', 'COMMCNT',
              'COMMPROG', 'IMGROW0', 'IMGCOL0', 'IMGSCALE', 'BGDAVG', 'BGDRMS',

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -40,7 +40,7 @@ def make_prob_regress_table():
     rows = []
     for model, mag, t_ccd, color, spoiler, halfwidth in itertools.product(
             models, mags, t_ccds, colors, spoilers, halfwidths):
-        prob = acq_success_prob(date='2018:001', t_ccd=t_ccd, mag=mag, color=color,
+        prob = acq_success_prob(date='2018:001:12:00:00', t_ccd=t_ccd, mag=mag, color=color,
                                 spoiler=spoiler, halfwidth=halfwidth,
                                 model=model)
         rows.append([model, mag, t_ccd, color, spoiler, halfwidth, prob])
@@ -53,7 +53,7 @@ def make_prob_regress_table():
 def test_acq_probs_values():
     dat = Table.read(ACQ_PROBS_FILE, format='ascii.ecsv', guess=False)
     for model, mag, t_ccd, color, spoiler, halfwidth, prob in dat:
-        prob_now = acq_success_prob(date='2018:001', t_ccd=t_ccd, mag=mag, color=color,
+        prob_now = acq_success_prob(date='2018:001:12:00:00', t_ccd=t_ccd, mag=mag, color=color,
                                     spoiler=spoiler, halfwidth=halfwidth,
                                     model=model)
         # Values written to file rounded to 1e-5, so test to 2e-5
@@ -61,32 +61,32 @@ def test_acq_probs_values():
 
 
 def test_t_ccd_warm_limit_1():
-    out = t_ccd_warm_limit([10.4] * 6, date='2015:001', min_n_acq=(2, 8e-3), model='sota')
+    out = t_ccd_warm_limit([10.4] * 6, date='2015:001:12:00:00', min_n_acq=(2, 8e-3), model='sota')
     assert np.allclose(out[0], -14.9924, atol=0.01, rtol=0)
     assert np.allclose(out[1], 0.008, atol=0.0001, rtol=0)
 
 
 def test_t_ccd_warm_limit_1_spline():
-    out = t_ccd_warm_limit([10.0] * 6, date='2018:180', min_n_acq=(2, 8e-3), model='spline')
+    out = t_ccd_warm_limit([10.0] * 6, date='2018:180:12:00:00', min_n_acq=(2, 8e-3), model='spline')
     assert np.allclose(out[0], -10.582, atol=0.01, rtol=0)
     assert np.allclose(out[1], 0.008, atol=0.0001, rtol=0)
 
 
 def test_t_ccd_warm_limit_2():
-    out = t_ccd_warm_limit([10.4] * 6, date='2015:001', min_n_acq=5.0, model='sota')
+    out = t_ccd_warm_limit([10.4] * 6, date='2015:001:12:00:00', min_n_acq=5.0, model='sota')
     assert np.allclose(out[0], -14.851, atol=0.01, rtol=0)
     assert np.allclose(out[1], 5.0, atol=0.01, rtol=0)
 
 
 def test_t_ccd_warm_limit_2_spline():
-    out = t_ccd_warm_limit([10.0] * 6, date='2018:180', min_n_acq=5.0, model='spline')
+    out = t_ccd_warm_limit([10.0] * 6, date='2018:180:12:00:00', min_n_acq=5.0, model='spline')
     assert np.allclose(out[0], -10.491, atol=0.01, rtol=0)
     assert np.allclose(out[1], 5.0, atol=0.01, rtol=0)
 
 
 def test_t_ccd_warm_limit_3():
     halfwidth = [40, 80, 120, 160, 180, 240]
-    box = t_ccd_warm_limit([10.4] * 6, date='2015:001', halfwidths=halfwidth,
+    box = t_ccd_warm_limit([10.4] * 6, date='2015:001:12:00:00', halfwidths=halfwidth,
                            min_n_acq=(2, 8e-3), model='sota')
     assert np.allclose(box[0], -15.6325, atol=0.01, rtol=0)
     assert np.allclose(box[1], 0.008, atol=0.0001, rtol=0)
@@ -94,7 +94,7 @@ def test_t_ccd_warm_limit_3():
 
 def test_t_ccd_warm_limit_3_spline():
     halfwidth = [40, 80, 120, 160, 180, 240]
-    box = t_ccd_warm_limit([10.0] * 6, date='2018:180', halfwidths=halfwidth,
+    box = t_ccd_warm_limit([10.0] * 6, date='2018:180:12:00:00', halfwidths=halfwidth,
                            min_n_acq=(2, 8e-3), model='spline')
     assert np.allclose(box[0], -11.0192, atol=0.01, rtol=0)
     assert np.allclose(box[1], 0.008, atol=0.0001, rtol=0)
@@ -169,21 +169,21 @@ def stepwise_guide_warm_limit(mags, step=0.01, min_guide_count=4.0,
 
 
 def test_mag_for_p_acq():
-    mag = mag_for_p_acq(0.50, date='2015:001', t_ccd=-14.0, model='sota')
+    mag = mag_for_p_acq(0.50, date='2015:001:12:00:00', t_ccd=-14.0, model='sota')
     assert np.allclose(mag, 10.848, rtol=0, atol=0.01)
 
 
 def test_halfwidth_adjustment():
     mag = 10.3
     halfwidth = [40, 80, 120, 180, 240]
-    p120 = acq_success_prob(mag=mag, date='2018:001', t_ccd=-19, halfwidth=120, model='sota')
-    pacq = acq_success_prob(mag=mag, date='2018:001', t_ccd=-19, halfwidth=halfwidth, model='sota')
+    p120 = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=120, model='sota')
+    pacq = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=halfwidth, model='sota')
     mults = pacq / p120
     assert np.allclose(mults, [1.07260318, 1.04512285, 1., 0.91312975, 0.83667405])
 
 
 def test_acq_success_prob_date():
-    date = ['2014:001', '2015:001', '2016:001', '2017:001']
+    date = ['2014:001:12:00:00', '2015:001:12:00:00', '2016:001:12:00:00', '2017:001:12:00:00']
     probs = acq_success_prob(date=date, t_ccd=-10, mag=10.3, spoiler=False, color=0.6,
                              model='sota')
     assert np.allclose(probs, [0.76856955, 0.74345895, 0.71609812, 0.68643974])
@@ -191,14 +191,14 @@ def test_acq_success_prob_date():
 
 def test_acq_success_prob_t_ccd():
     t_ccd = [-16, -14, -12, -10]
-    probs = acq_success_prob(date='2017:001', t_ccd=t_ccd, mag=10.3, spoiler=False, color=0.6,
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=t_ccd, mag=10.3, spoiler=False, color=0.6,
                              model='sota')
     assert np.allclose(probs, [0.87007558, 0.81918958, 0.75767782, 0.68643974])
 
 
 def test_acq_success_prob_mag():
     mag = [9, 10, 10.3, 10.6]
-    probs = acq_success_prob(date='2017:001', t_ccd=-10, mag=mag, spoiler=False, color=0.6,
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=mag, spoiler=False, color=0.6,
                              model='sota')
     assert np.allclose(probs, [0.985, 0.86868674, 0.68643974, 0.3952578])
 
@@ -206,7 +206,7 @@ def test_acq_success_prob_mag():
 def test_acq_success_prob_spoiler():
     p_spoiler = .9241  # probability multiplier for a search-spoiled star (REF?)
     spoiler = [False, True]
-    probs = acq_success_prob(date='2017:001', t_ccd=-10, mag=10.3, spoiler=spoiler, color=0.6,
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=spoiler, color=0.6,
                              model='sota')
     assert np.allclose(p_spoiler, probs[1] / probs[0])
 
@@ -214,7 +214,7 @@ def test_acq_success_prob_spoiler():
 def test_acq_success_prob_color():
     p_0p7color = .4294  # probability multiplier for a B-V = 0.700 star (REF?)
     color = [0.6, 0.699997, 0.69999999, 0.7, 0.700001, 1.5, 1.49999999]
-    probs = acq_success_prob(date='2017:001', t_ccd=-10, mag=10.3, spoiler=False, color=color,
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=False, color=color,
                              model='sota')
     assert np.allclose(probs, [0.68643974, 0.68643974, 0.29475723, 0.29475723, 0.68643974,
                                0.29295036, 0.29295036])
@@ -255,13 +255,13 @@ def test_acq_success_prob_from_stars():
     hws = [160, 160, 120, 160, 120, 120, 120, 120]
 
     # SOTA
-    probs = acq_success_prob(date='2018:059', t_ccd=-11.2, mag=mags, color=colors,
+    probs = acq_success_prob(date='2018:059:12:00:00', t_ccd=-11.2, mag=mags, color=colors,
                              halfwidth=hws, model='sota')
     assert np.allclose(probs, [0.977, 0.967, 0.793, 0.775, 0.606, 0.0004, 0.704, 0.651],
                        atol=1e-2, rtol=0)
 
     # Spline
-    probs = acq_success_prob(date='2018:059', t_ccd=-11.2, mag=mags, color=colors,
+    probs = acq_success_prob(date='2018:059:12:00:00', t_ccd=-11.2, mag=mags, color=colors,
                              halfwidth=hws, model='spline')
     assert np.allclose(probs, [0.954, 0.936, 0.696, 0.739, 0.297, 0.000001, 0.491, 0.380],
                        atol=1e-2, rtol=0)

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -67,7 +67,8 @@ def test_t_ccd_warm_limit_1():
 
 
 def test_t_ccd_warm_limit_1_spline():
-    out = t_ccd_warm_limit([10.0] * 6, date='2018:180:12:00:00', min_n_acq=(2, 8e-3), model='spline')
+    out = t_ccd_warm_limit([10.0] * 6, date='2018:180:12:00:00', min_n_acq=(2, 8e-3),
+                           model='spline')
     assert np.allclose(out[0], -10.582, atol=0.01, rtol=0)
     assert np.allclose(out[1], 0.008, atol=0.0001, rtol=0)
 
@@ -176,8 +177,10 @@ def test_mag_for_p_acq():
 def test_halfwidth_adjustment():
     mag = 10.3
     halfwidth = [40, 80, 120, 180, 240]
-    p120 = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=120, model='sota')
-    pacq = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=halfwidth, model='sota')
+    p120 = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=120,
+                            model='sota')
+    pacq = acq_success_prob(mag=mag, date='2018:001:12:00:00', t_ccd=-19, halfwidth=halfwidth,
+                            model='sota')
     mults = pacq / p120
     assert np.allclose(mults, [1.07260318, 1.04512285, 1., 0.91312975, 0.83667405])
 
@@ -191,7 +194,8 @@ def test_acq_success_prob_date():
 
 def test_acq_success_prob_t_ccd():
     t_ccd = [-16, -14, -12, -10]
-    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=t_ccd, mag=10.3, spoiler=False, color=0.6,
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=t_ccd, mag=10.3, spoiler=False,
+                             color=0.6,
                              model='sota')
     assert np.allclose(probs, [0.87007558, 0.81918958, 0.75767782, 0.68643974])
 
@@ -206,16 +210,16 @@ def test_acq_success_prob_mag():
 def test_acq_success_prob_spoiler():
     p_spoiler = .9241  # probability multiplier for a search-spoiled star (REF?)
     spoiler = [False, True]
-    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=spoiler, color=0.6,
-                             model='sota')
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=spoiler,
+                             color=0.6, model='sota')
     assert np.allclose(p_spoiler, probs[1] / probs[0])
 
 
 def test_acq_success_prob_color():
     p_0p7color = .4294  # probability multiplier for a B-V = 0.700 star (REF?)
     color = [0.6, 0.699997, 0.69999999, 0.7, 0.700001, 1.5, 1.49999999]
-    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=False, color=color,
-                             model='sota')
+    probs = acq_success_prob(date='2017:001:12:00:00', t_ccd=-10, mag=10.3, spoiler=False,
+                             color=color, model='sota')
     assert np.allclose(probs, [0.68643974, 0.68643974, 0.29475723, 0.29475723, 0.68643974,
                                0.29295036, 0.29295036])
     assert np.allclose(p_0p7color, probs[2] / probs[0])


### PR DESCRIPTION
## Description

Non-controversial changes to get tests passing on shiny. The only interesting one is that comparing a table row that has an image with masked entries works with astropy 3.0 and numpy 1.12 but not in shiny. I didn't drill to the bottom of this, but in any case astropy 4.1 changes the behavior of table comparison to be more reasonable.

## Testing

- [x] Passes unit tests on MacOS (shiny)
- [x] Passes unit tests on MacOS (flight)
- [N/A] Functional testing
