### PR TITLE
Unified documentation style

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+---
+name: Deploy Docs
+on:
+  release:
+    types:
+    - created
+  repository_dispatch:
+    types:
+    - build-docs
+
+jobs:
+  build-linux:
+    runs-on: head
+    name: Deploy Docs
+    steps:
+      - name: Fetch gh-pages
+        uses: actions/checkout@v2
+        with:
+          path: gh-pages
+          ref: gh-pages
+      - name: Fetch source
+        uses: actions/checkout@v2
+        with:
+          path: source
+      - name: clear
+        run: rm -fr gh-pages/docs/*
+      - name: build
+        run: |
+          eval "$(/export/jgonzale/github-workflows/miniconda3-shiny/bin/conda shell.bash hook)"
+          conda activate ska3-masters
+          mkdir -p _static
+          make html
+        working-directory: source/docs
+        env:
+          PYTHONPATH: ${{ github.workspace }}/source
+          GITHUB_API_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}
+      - name: copy
+        run: cp -fr source/docs/_build/html/* gh-pages/docs
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          ref: "gh-pages"
+          cwd: "gh-pages"
+          author_name: Javier Gonzalez
+          author_email: javierggt@yahoo.com
+          message: "Deploy docs"
+          add: "docs"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -458,8 +458,9 @@ def get_raw_aca_packets(start, stop, **maude_kwargs):
 
     :param start: timestamp interpreted as a Chandra.Time.DateTime
     :param stop: timestamp interpreted as a Chandra.Time.DateTime
-    :param **maude_kwargs: keyword args passed to maude.get_frames()
+    :param ``**maude_kwargs``: keyword args passed to maude.get_frames()
     :return: dict
+
         {'flags': int, 'packets': [],
          'TIME': np.array([]), 'MNF': np.array([]), 'MJF': np.array([])}
     """
@@ -710,7 +711,7 @@ def get_aca_packets(start, stop, level0=False,
     :param calibrate: bool
         If True, pixel values will be 'value * imgscale / 32 - 50' and temperature values will
         be: 0.4 * value + 273.15
-    :param **maude_kwargs: keyword args passed to maude
+    :param ``**maude_kwargs``: keyword args passed to maude
     :return: astropy.table.Table
     """
     if level0:
@@ -811,7 +812,7 @@ def get_aca_images(start, stop, **maude_kwargs):
 
     :param start: timestamp interpreted as a Chandra.Time.DateTime
     :param stop: timestamp interpreted as a Chandra.Time.DateTime
-    :param **maude_kwargs: keyword args passed to maude
+    :param ``**maude_kwargs``: keyword args passed to maude
     :return: astropy.table.Table
     """
     return get_aca_packets(start, stop, level0=True, **maude_kwargs)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,12 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 # html_theme = 'classic'
+html_theme = 'bootstrap-ska'
+html_theme_options = {
+    'logotext1': 'Ska! ',  # white,  semi-bold
+    'logotext2': 'chandra_aca',  # orange, light
+    'logotext3': '',   # white,  light
+    }
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,9 @@ html_theme_options = {
     'logotext1': 'Ska! ',  # white,  semi-bold
     'logotext2': 'chandra_aca',  # orange, light
     'logotext3': '',   # white,  light
+    'homepage_url': 'https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc',
+    'homepage_text': 'ska',
+    'homepage_text_2': 'tools'
     }
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
This PR changes the documentation to unify style among all ska packages. Documentation is always in the docs directory, with configuration in conf.py, and uses the ska theme.

This PR also includes trivial changes for documentation:
- Escape `**kwargs` with double backticks