### PR TITLE
Improve setup.py for ephemeris data download

### DIFF
--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -21,7 +21,7 @@ def load_kernel():
     kernel_path = Path(__file__).parent / 'data' / 'de432s.bsp'
     if not kernel_path.exists():
         raise FileNotFoundError(f'kernel data file {kernel_path} not found, '
-                                'run "python setup.py --version" to install it locally')
+                                'run "python setup.py build" to install it locally')
     kernel = SPK.open(kernel_path)
     return kernel
 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,11 @@ except ImportError:
 # but included in the distribution at chandra_aca/data/de432s.bsp (11 Mb).
 ephem_file = Path('chandra_aca', 'data', 'de432s.bsp')
 if not ephem_file.exists():
-    from astropy.utils.data import download_file
+    import urllib.request
     import shutil
     url = 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp'
-    file = download_file(url, cache=True, show_progress=False)
-    shutil.copy(file, ephem_file)
-
+    with urllib.request.urlopen(url, timeout=60) as f_in, open(ephem_file, 'wb') as f_out:
+        shutil.copyfileobj(f_in, f_out)
 
 setup(name='chandra_aca',
       author='Jean Connelly, Tom Aldcroft',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
 from setuptools import setup
 from pathlib import Path
 
@@ -11,7 +12,7 @@ except ImportError:
 # Check for de432s.bsp JPL ephemeris file. This is not kept in the git repo
 # but included in the distribution at chandra_aca/data/de432s.bsp (11 Mb).
 ephem_file = Path('chandra_aca', 'data', 'de432s.bsp')
-if not ephem_file.exists():
+if '--version' not in sys.argv and not ephem_file.exists():
     import urllib.request
     import shutil
     url = 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de432s.bsp'


### PR DESCRIPTION
## Description

Improve setup.py for ephemeris data download to only use standard library packages.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

I removed the existing `chandra_aca/data/de432s.bsp` file and then ran `python setup.py --version` to re-download. After that I ran the unit tests with no fails.