### PR TITLE
Improve _aca_packets_to_table speed by factor of 20

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -549,9 +549,9 @@ def _aca_packets_to_table(aca_packets):
     for i, aca_packet in enumerate(aca_packets):
         if 'IMG' in aca_packet:
             img.append(aca_packet['IMG'])
-        for k in names:
-            if k in aca_packet:
-                array[i][k] = aca_packet[k]
+        for name in names:
+            if name in aca_packet:
+                array[name][i] = aca_packet[name]
 
     table = Table(array)
     if img:


### PR DESCRIPTION
## Description

It turns out that assigning a masked array using row-oriented `array[idx][name]` is *extremely* slow. This one operation was completely dominating the time for doing ACA telemetry decom. This meant that the decom was much slower than fetching from MAUDE.  Instead use column oriented `array[name][idx]` and the `_aca_packets_to_table` function is 20 times faster and fetching from MAUDE is now about 60% of the time.

At the top level, this reduces the time to fetch and decom 5 minutes of telemetry from about 9 seconds to 1.6 seconds, and will thus improve the aca_view performance substantially.

I took the liberty of renaming a variable from `k` to `name` so that it is obviously a column name not an integer index.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### WITH the patch
```
In [4]: %lprun -f _aca_packets_to_table get_aca_packets('2020:003:00:31:00', '2020:003:00:32:00')                                                                            

   Total time: 0.485798 s
File: /Users/aldcroft/git/chandra_aca/chandra_aca/maude_decom.py
Function: _aca_packets_to_table at line 519

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   519                                           def _aca_packets_to_table(aca_packets):
   520                                               """
   521                                               Store ACA packets in a table.
   522                                           
   523                                               :param aca_packets: list of dict
   524                                               :return: astropy.table.Table
   525                                               """
   526         1          3.0      3.0      0.0      import copy
   527         2         13.0      6.5      0.0      dtype = np.dtype(
   528         2          3.0      1.5      0.0          [('TIME', np.float64), ('VCDUCTR', np.uint32), ('MJF', np.uint32), ('MNF', np.uint32),
   529         1          1.0      1.0      0.0           ('IMGNUM', np.uint32), ('COMMCNT', np.uint8), ('COMMPROG', np.uint8),
   530         1          1.0      1.0      0.0           ('GLBSTAT', np.uint8), ('IMGFUNC', np.uint32), ('IMGTYPE', np.uint8),
   531         1          1.0      1.0      0.0           ('IMGSCALE', np.uint16), ('IMGROW0', np.int16), ('IMGCOL0', np.int16),
   532         1          1.0      1.0      0.0           ('INTEG', np.uint16), ('BGDAVG', np.uint16), ('BGDRMS', np.uint16), ('TEMPCCD', np.int16),
   533         1          1.0      1.0      0.0           ('TEMPHOUS', np.int16), ('TEMPPRIM', np.int16), ('TEMPSEC', np.int16),
   534         1          1.0      1.0      0.0           ('BGDSTAT', np.uint8), ('HIGH_BGD', np.bool), ('RAM_FAIL', np.bool),
   535         1          1.0      1.0      0.0           ('ROM_FAIL', np.bool), ('POWER_FAIL', np.bool), ('CAL_FAIL', np.bool),
   536         1          1.0      1.0      0.0           ('COMM_CHECKSUM_FAIL', np.bool), ('RESET', np.bool), ('SYNTAX_ERROR', np.bool),
   537         1          1.0      1.0      0.0           ('COMMCNT_SYNTAX_ERROR', np.bool), ('COMMCNT_CHECKSUM_FAIL', np.bool),
   538         1          1.0      1.0      0.0           ('COMMPROG_REPEAT', np.uint8), ('IMGFID', np.bool),
   539         1          1.0      1.0      0.0           ('IMGSTAT', np.uint8), ('SAT_PIXEL', np.bool), ('DEF_PIXEL', np.bool),
   540         1          1.0      1.0      0.0           ('QUAD_BOUND', np.bool), ('COMMON_COL', np.bool), ('MULTI_STAR', np.bool),
   541         1          0.0      0.0      0.0           ('ION_RAD', np.bool), ('IMGROW_A1', np.int16), ('IMGCOL_A1', np.int16),
   542         1          1.0      1.0      0.0           ('IMGROW0_8X8', np.int16), ('IMGCOL0_8X8', np.int16), ('END_INTEG_TIME', np.float64),
   543         1          0.0      0.0      0.0           ('PIXTLM', np.uint8), ('BGDTYP', np.uint8),
   544                                                    ])
   545                                           
   546         1        921.0    921.0      0.2      array = np.ma.masked_all(len(aca_packets), dtype=dtype)
   547         1        132.0    132.0      0.0      names = copy.deepcopy(dtype.names)
   548         1          1.0      1.0      0.0      img = []
   549       473        350.0      0.7      0.1      for i, aca_packet in enumerate(aca_packets):
   550       472        377.0      0.8      0.1          if 'IMG' in aca_packet:
   551       472        420.0      0.9      0.1              img.append(aca_packet['IMG'])
   552     22656      14429.0      0.6      3.0          for name in names:
   553     22184      14780.0      0.7      3.0              if name in aca_packet:
   554     14916     439389.0     29.5     90.4                  array[name][i] = aca_packet[name]
   555                                           
   556         1      11642.0  11642.0      2.4      table = Table(array)
   557         1          1.0      1.0      0.0      if img:
   558         1       1112.0   1112.0      0.2          table['IMG'] = img
   559       473        322.0      0.7      0.1          for i, aca_packet in enumerate(aca_packets):
   560       472       1889.0      4.0      0.4              table['IMG'].mask[i] = aca_packet['IMG'].mask
   561         1          1.0      1.0      0.0      return table

```

### WITHOUT the patch (current master)
```


In [4]: %lprun -f _aca_packets_to_table get_aca_packets('2020:003:00:31:00', '2020:003:00:32:00')                                                                            
Timer unit: 1e-06 s
Timer unit: 1e-06 s

Total time: 8.40909 s
File: /Users/aldcroft/git/chandra_aca/chandra_aca/maude_decom.py
Function: _aca_packets_to_table at line 519

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   519                                           def _aca_packets_to_table(aca_packets):
   520                                               """
   521                                               Store ACA packets in a table.
   522                                           
   523                                               :param aca_packets: list of dict
   524                                               :return: astropy.table.Table
   525                                               """
   526         1          3.0      3.0      0.0      import copy
   527         2         13.0      6.5      0.0      dtype = np.dtype(
   528         2          2.0      1.0      0.0          [('TIME', np.float64), ('VCDUCTR', np.uint32), ('MJF', np.uint32), ('MNF', np.uint32),
   529         1          1.0      1.0      0.0           ('IMGNUM', np.uint32), ('COMMCNT', np.uint8), ('COMMPROG', np.uint8),
   530         1          0.0      0.0      0.0           ('GLBSTAT', np.uint8), ('IMGFUNC', np.uint32), ('IMGTYPE', np.uint8),
   531         1          1.0      1.0      0.0           ('IMGSCALE', np.uint16), ('IMGROW0', np.int16), ('IMGCOL0', np.int16),
   532         1          1.0      1.0      0.0           ('INTEG', np.uint16), ('BGDAVG', np.uint16), ('BGDRMS', np.uint16), ('TEMPCCD', np.int16),
   533         1          1.0      1.0      0.0           ('TEMPHOUS', np.int16), ('TEMPPRIM', np.int16), ('TEMPSEC', np.int16),
   534         1          1.0      1.0      0.0           ('BGDSTAT', np.uint8), ('HIGH_BGD', np.bool), ('RAM_FAIL', np.bool),
   535         1          0.0      0.0      0.0           ('ROM_FAIL', np.bool), ('POWER_FAIL', np.bool), ('CAL_FAIL', np.bool),
   536         1          1.0      1.0      0.0           ('COMM_CHECKSUM_FAIL', np.bool), ('RESET', np.bool), ('SYNTAX_ERROR', np.bool),
   537         1          1.0      1.0      0.0           ('COMMCNT_SYNTAX_ERROR', np.bool), ('COMMCNT_CHECKSUM_FAIL', np.bool),
   538         1          1.0      1.0      0.0           ('COMMPROG_REPEAT', np.uint8), ('IMGFID', np.bool),
   539         1          0.0      0.0      0.0           ('IMGSTAT', np.uint8), ('SAT_PIXEL', np.bool), ('DEF_PIXEL', np.bool),
   540         1          1.0      1.0      0.0           ('QUAD_BOUND', np.bool), ('COMMON_COL', np.bool), ('MULTI_STAR', np.bool),
   541         1          0.0      0.0      0.0           ('ION_RAD', np.bool), ('IMGROW_A1', np.int16), ('IMGCOL_A1', np.int16),
   542         1          1.0      1.0      0.0           ('IMGROW0_8X8', np.int16), ('IMGCOL0_8X8', np.int16), ('END_INTEG_TIME', np.float64),
   543         1          0.0      0.0      0.0           ('PIXTLM', np.uint8), ('BGDTYP', np.uint8),
   544                                                    ])
   545                                           
   546         1        926.0    926.0      0.0      array = np.ma.masked_all(len(aca_packets), dtype=dtype)
   547         1        127.0    127.0      0.0      names = copy.deepcopy(dtype.names)
   548         1          1.0      1.0      0.0      img = []
   549       473        419.0      0.9      0.0      for i, aca_packet in enumerate(aca_packets):
   550       472        465.0      1.0      0.0          if 'IMG' in aca_packet:
   551       472        499.0      1.1      0.0              img.append(aca_packet['IMG'])
   552     22656      17729.0      0.8      0.2          for name in names:
   553     22184      15945.0      0.7      0.2              if name in aca_packet:
   554     14916    8358779.0    560.4     99.4                  array[i][name] = aca_packet[name]
   555                                           
   556         1      11026.0  11026.0      0.1      table = Table(array)
   557         1          1.0      1.0      0.0      if img:
   558         1        977.0    977.0      0.0          table['IMG'] = img
   559       473        321.0      0.7      0.0          for i, aca_packet in enumerate(aca_packets):
   560       472       1847.0      3.9      0.0              table['IMG'].mask[i] = aca_packet['IMG'].mask
   561         1          0.0      0.0      0.0      return table
```
