### PR TITLE
Fix aca_view issue 57, need masked=True in Table creation

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -553,7 +553,7 @@ def _aca_packets_to_table(aca_packets):
             if k in aca_packet:
                 array[i][k] = aca_packet[k]
 
-    table = Table(array)
+    table = Table(array, masked=True)
     if img:
         table['IMG'] = img
         for i, aca_packet in enumerate(aca_packets):


### PR DESCRIPTION
## Description

The astropy Table class changed behavior so that a Table can hold both MaskedColumn and Column at once. The fix here is to force all MaskedColumn with `masked=True`. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing - fixes the problem in aca_view

Fixes https://github.com/sot/aca_view/issues/57