### PR TITLE
Calculate row/col of planet even if off CCD

### DIFF
--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -347,7 +347,7 @@ def _plot_planets(ax, att, date0, duration):
         eci = get_planet_chandra(planet, dates)
         ra, dec = eci_to_radec(eci)
         yag, zag = radec_to_yagzag(ra, dec, att)
-        row, col = yagzag_to_pixels(yag, zag)
+        row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
 
         # Plot with green at beginning, red at ending
         ax.plot(row, col, '.', color='m', alpha=0.5)


### PR DESCRIPTION
## Description
Calculate row/col of planet even if off CCD (by using allow_bad=True in yagzag_to_pixels).

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Functional test:

Allows this:
```
plot_stars([-0.45749853478319497,, 0.4309589967008305, -0.2887493342348751, 0.7222141343208118], starcat_time='2020:328:22:56:56.820', duration=10000)
``` 
to work without throwing a "ValueError: Coordinate off CCD".  I don't *think* this deserves a unit test but that's available if we want it.
