### PR TITLE
Fetch ACA telemetry from MAUDE using blobs

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -77,7 +77,7 @@ In the following tables, column index increases to the right and row index incre
 from struct import unpack as _unpack, Struct
 import numpy as np
 
-from astropy.table import Table, vstack, MaskedColumn
+from astropy.table import Table, vstack
 import maude
 
 from Chandra.Time import DateTime

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -130,13 +130,12 @@ def _aca_msid_list(pea):
     # helper method to make a dictionary with all global (non-slot) MSIDs used here
     return {
         'status': 'AOACSTAT',  # ASPECT CAMERA DATA PROCESSING OVERALL STATUS FLAG
-        'command_count': f'{_msid_prefix[pea]}CCMDS',
         'integration_time': f'{_msid_prefix[pea]}ACAINT0',
         'major_frame': 'CVCMJCTR',
         'minor_frame': 'CVCMNCTR',
         'cmd_count': f'{_msid_prefix[pea]}CCMDS',
-        'cmd_progress': f'{_msid_prefix[pea]}AROW2GO'  # NUMBER OF ROWS TO GO COMMAND PROGRESS
-
+        'cmd_progress_to_go': f'{_msid_prefix[pea]}AROW2GO',  # No. of ROWS TO GO COMMAND PROGRESS
+        'cmd_progress': 'AOCMDPG1'  # COMMAND PROGRESS COUNT
     }
 
 
@@ -148,8 +147,8 @@ def _aca_image_msid_list(pea):
     px_nums = [str(n) for n in range(1, 5)]
     px_img_nums = [str(n) for n in range(8)]
 
-    pixels = [[f'{msid_prefix}CIMG{px_img_num}{px_id}{px_num}'
-               for px_num in px_nums for px_id in px_ids]
+    pixels = [sorted([f'{msid_prefix}CIMG{px_img_num}{px_id}{px_num}'
+               for px_num in px_nums for px_id in px_ids])
               for px_img_num in px_img_nums]
 
     res = {
@@ -197,6 +196,13 @@ def _aca_image_msid_list(pea):
         # 'image_function_pea':
         #     [f'{msid_prefix}AIMGF{i}1' for i in range(8)],  # IMAGE FUNCTION1 (PEA)
 
+        'saturated_pixel': [f'{msid_prefix}ASPXF{i}' for i in range(8)], # DEFECTIVE PIXEL FLAG
+        'defective_pixel': [f'{msid_prefix}ADPXF{i}' for i in range(8)], # SATURATED PIXEL FLAG
+        'quad_bound': [f'{msid_prefix}QBNDF{i}' for i in range(8)],  # QUADRANT BOUNDRY FLAG
+        'common_col': [f'{msid_prefix}ACOLF{i}' for i in range(8)],  # COMMON COLUMN FLAG
+        'multi_star': [f'{msid_prefix}AMSTF{i}' for i in range(8)],  # MULTIPLE STAR FLAG
+        'ion_rad': [f'{msid_prefix}AIRDF{i}' for i in range(8)],  # IONIZING RADIATION FLAG
+
         'background_rms': [f'{msid_prefix}CRMSBG{i}' for i in range(8)],
         'background_avg': [f'{msid_prefix}CA00110', f'{msid_prefix}CA00326',
                            f'{msid_prefix}CA00542', f'{msid_prefix}CA00758',
@@ -213,6 +219,10 @@ def _aca_image_msid_list(pea):
         'magnitude': [f'AOACMAG{i}' for i in range(8)],       # STAR OR FIDUCIAL MAGNITUDE (OBC)
         'centroid_ang_y': [f'AOACYAN{i}' for i in range(8)],  # YAG CENTROID Y ANGLE (OBC)
         'centroid_ang_z': [f'AOACZAN{i}' for i in range(8)],  # ZAG CENTROID Z ANGLE (OBC)
+
+        'bgd_stat_pixels': [[f'ACBPX{j}1{i}' for j in 'ABGH'] +
+                            [f'ACBPX{j}4{i}' for j in 'IJOP']
+                            for i in range(8)]
     }
     return [{k: res[k][i] for k in res.keys()} for i in range(8)]
 

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1036,13 +1036,16 @@ def blob_to_aca_image_dict(blob, imgnum, pea=1):
         })
 
     if 'AOATTQT1' in blob:
-        result['AOATTQT1'] = blob['AOATTQT1']
+        result['AOATTQT1'] = float(blob['AOATTQT1'])
     if 'AOATTQT2' in blob:
-        result['AOATTQT1'] = blob['AOATTQT2']
+        result['AOATTQT2'] = float(blob['AOATTQT2'])
     if 'AOATTQT3' in blob:
-        result['AOATTQT3'] = blob['AOATTQT3']
+        result['AOATTQT3'] = float(blob['AOATTQT3'])
     if 'AOATTQT4' in blob:
-        result['AOATTQT4'] = blob['AOATTQT4']
+        result['AOATTQT4'] = float(blob['AOATTQT4'])
+
+    if 'COBSRQID' in blob:
+        result['COBSRQID'] = int(blob['COBSRQID'])
 
     return result
 

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -77,7 +77,7 @@ In the following tables, column index increases to the right and row index incre
 from struct import unpack as _unpack, Struct
 import numpy as np
 
-from astropy.table import Table, vstack
+from astropy.table import Table, vstack, MaskedColumn
 import maude
 
 from Chandra.Time import DateTime
@@ -148,7 +148,7 @@ def _aca_image_msid_list(pea):
     px_img_nums = [str(n) for n in range(8)]
 
     pixels = [sorted([f'{msid_prefix}CIMG{px_img_num}{px_id}{px_num}'
-               for px_num in px_nums for px_id in px_ids])
+              for px_num in px_nums for px_id in px_ids])
               for px_img_num in px_img_nums]
 
     res = {
@@ -196,8 +196,8 @@ def _aca_image_msid_list(pea):
         # 'image_function_pea':
         #     [f'{msid_prefix}AIMGF{i}1' for i in range(8)],  # IMAGE FUNCTION1 (PEA)
 
-        'saturated_pixel': [f'{msid_prefix}ASPXF{i}' for i in range(8)], # DEFECTIVE PIXEL FLAG
-        'defective_pixel': [f'{msid_prefix}ADPXF{i}' for i in range(8)], # SATURATED PIXEL FLAG
+        'saturated_pixel': [f'{msid_prefix}ASPXF{i}' for i in range(8)],  # DEFECTIVE PIXEL FLAG
+        'defective_pixel': [f'{msid_prefix}ADPXF{i}' for i in range(8)],  # SATURATED PIXEL FLAG
         'quad_bound': [f'{msid_prefix}QBNDF{i}' for i in range(8)],  # QUADRANT BOUNDRY FLAG
         'common_col': [f'{msid_prefix}ACOLF{i}' for i in range(8)],  # COMMON COLUMN FLAG
         'multi_star': [f'{msid_prefix}AMSTF{i}' for i in range(8)],  # MULTIPLE STAR FLAG
@@ -455,7 +455,7 @@ def _group_packets(packets, discard=True):
         yield res
 
 
-def get_raw_aca_packets(start, stop, **maude_kwargs):
+def get_raw_aca_packets(start, stop, maude_result=None, **maude_kwargs):
     """
     Fetch 1025-byte VCDU frames using MAUDE and extract a list of 225-byte ACA packets.
 
@@ -468,7 +468,8 @@ def get_raw_aca_packets(start, stop, **maude_kwargs):
 
     :param start: timestamp interpreted as a Chandra.Time.DateTime
     :param stop: timestamp interpreted as a Chandra.Time.DateTime
-    :param ``**maude_kwargs``: keyword args passed to maude.get_frames()
+    :param maude_result: the result of calling maude.get_frames. Optional.
+    :param maude_kwargs: keyword args passed to maude.get_frames()
     :return: dict
 
         {'flags': int, 'packets': [],
@@ -500,7 +501,12 @@ def get_raw_aca_packets(start, stop, **maude_kwargs):
               (aca_frame_times[:, 0] <= date_stop.secs))
 
     # get the frames and unpack front matter
-    frames = maude.get_frames(start=date_start, stop=date_stop + stop_pad, **maude_kwargs)['data']
+    if maude_result is None:
+        frames = maude.get_frames(start=date_start,
+                                  stop=date_stop + stop_pad,
+                                  **maude_kwargs)['data']
+    else:
+        frames = maude_result['data']
     flags = frames['f']
     frames = frames['frames']
 
@@ -547,7 +553,7 @@ ACA_PACKETS_DTYPE = np.dtype(
 )
 
 
-def _aca_packets_to_table(aca_packets, dtype=ACA_PACKETS_DTYPE):
+def _aca_packets_to_table(aca_packets, dtype=None):
     """
     Store ACA packets in a table.
 
@@ -557,7 +563,10 @@ def _aca_packets_to_table(aca_packets, dtype=ACA_PACKETS_DTYPE):
     """
     import copy
 
-    array = np.ma.masked_all(len(aca_packets), dtype=dtype)
+    if dtype is None:
+        dtype = ACA_PACKETS_DTYPE
+
+    array = np.ma.masked_all([len(aca_packets)], dtype=dtype)
     names = copy.deepcopy(dtype.names)
     img = []
     for i, aca_packet in enumerate(aca_packets):
@@ -577,6 +586,7 @@ def _aca_packets_to_table(aca_packets, dtype=ACA_PACKETS_DTYPE):
 
 def get_aca_packets(start, stop, level0=False,
                     combine=False, adjust_time=False, calibrate=False,
+                    blobs=None, frames=None, dtype=None,
                     **maude_kwargs):
     """
     Fetch VCDU 1025-byte frames, extract ACA packets, unpack them and store them in a table.
@@ -725,17 +735,33 @@ def get_aca_packets(start, stop, level0=False,
     :param calibrate: bool
         If True, pixel values will be 'value * imgscale / 32 - 50' and temperature values will
         be: 0.4 * value + 273.15
-    :param ``**maude_kwargs``: keyword args passed to maude
+    :param blobs: bool or dict
+        If set, data is assembled from MAUDE blobs. If it is a dictionary, it must be the
+        output of maude.get_blobs ({'blobs': ... }).
+    :param frames: bool or dict
+        If set, data is assembled from MAUDE frames. If it is a dictionary, it must be the
+        output of maude.get_frames ({'data': ... }).
+    :param dtype: np.dtype. Optional.
+        the dtype to use when creating the resulting table. This is useful to add columns
+        including MSIDs that are present in blobs. If used with frames, most probably you will get
+        and empty column. This option is intended to augment the default dtype. If a more
+        restrictive dtype is used, a KeyError can be raised.
+    :param maude_kwargs: keyword args passed to maude
     :return: astropy.table.Table
     """
+    if not blobs and not frames:
+        frames = True
+
+    assert (blobs and not frames) or (frames and not blobs), "Specify only one of 'frames' or blobs"
+
     if level0:
         adjust_time = True
         combine = True
         calibrate = True
 
-    start, stop = DateTime(start), DateTime(stop)  # ensure input is proper date
-    if 24 * (stop - start) > 3:
-        raise ValueError(f'Requested {24 * (stop - start)} hours of telemetry. '
+    date_start, date_stop = DateTime(start), DateTime(stop)  # ensure input is proper date
+    if 24 * (date_stop - date_start) > 3:
+        raise ValueError(f'Requested {24 * (date_stop - date_start)} hours of telemetry. '
                          'Maximum allowed is 3 hours at a time')
 
     stop_pad = 0
@@ -744,23 +770,38 @@ def get_aca_packets(start, stop, level0=False,
     if combine:
         stop_pad += 3.08 / 86400  # there can be trailing frames
 
-    n = int(np.ceil(86400 * (stop - start) / 300))
-    dt = (stop - start) / n
-    batches = [(start + i * dt, start + (i + 1) * dt) for i in range(n)]  # 0.0001????
-    aca_packets = []
-    for t1, t2 in batches:
-        raw_aca_packets = get_raw_aca_packets(t1, t2 + stop_pad, **maude_kwargs)
-        packets = _get_aca_packets(
-            raw_aca_packets, t1, t2,
-            combine=combine, adjust_time=adjust_time, calibrate=calibrate
-        )
-        aca_packets.append(packets)
-
-    return vstack(aca_packets)
+    if frames:
+        n = int(np.ceil(86400 * (date_stop - date_start) / 300))
+        dt = (date_stop - date_start) / n
+        batches = [(date_start + i * dt, date_start + (i + 1) * dt) for i in range(n)]  # 0.0001????
+        aca_packets = []
+        for t1, t2 in batches:
+            maude_result = frames if type(frames) is dict and 'data' in frames else None
+            raw_aca_packets = get_raw_aca_packets(t1, t2 + stop_pad,
+                                                  maude_result=maude_result,
+                                                  **maude_kwargs)
+            packets = _get_aca_packets(
+                raw_aca_packets, t1, t2,
+                combine=combine, adjust_time=adjust_time, calibrate=calibrate, dtype=dtype
+            )
+            aca_packets.append(packets)
+        aca_data = vstack(aca_packets)
+    else:
+        maude_result = frames if type(frames) is dict and 'data' in frames else None
+        merged_blobs = get_raw_aca_blobs(date_start, date_stop,
+                                         maude_result=maude_result,
+                                         **maude_kwargs)['blobs']
+        aca_packets = [[blob_to_aca_image_dict(b, i) for b in merged_blobs] for i in range(8)]
+        aca_data = _get_aca_packets(aca_packets, date_start, date_stop + stop_pad,
+                                    combine=combine, adjust_time=adjust_time, calibrate=calibrate,
+                                    blobs=True,
+                                    dtype=dtype)
+    return aca_data
 
 
 def _get_aca_packets(aca_packets, start, stop,
-                     combine=False, adjust_time=False, calibrate=False):
+                     combine=False, adjust_time=False, calibrate=False,
+                     blobs=False, dtype=None):
     """
     This is a convenience function that splits get_aca_packets for testing without MAUDE.
     Same arguments as get_aca_packets plus aca_packets, the raw ACA 225-byte packets.
@@ -769,23 +810,26 @@ def _get_aca_packets(aca_packets, start, stop,
     """
     start, stop = DateTime(start), DateTime(stop)  # ensure input is proper date
 
-    aca_packets['decom_packets'] = [unpack_aca_telemetry(a) for a in aca_packets['packets']]
-    for i in range(len(aca_packets['decom_packets'])):
-        for j in range(8):
-            aca_packets['decom_packets'][i][j]['TIME'] = aca_packets['TIME'][i]
-            aca_packets['decom_packets'][i][j]['MJF'] = aca_packets['MJF'][i]
-            aca_packets['decom_packets'][i][j]['MNF'] = aca_packets['MNF'][i]
-            if 'VCDUCTR' in aca_packets:
-                aca_packets['decom_packets'][i][j]['VCDUCTR'] = aca_packets['VCDUCTR'][i]
-            aca_packets['decom_packets'][i][j]['IMGNUM'] = j
+    if not blobs:
+        # this adds TIME, MJF, MNF and VCDUCTR, which is already there in the blob dictionary
+        aca_packets['decom_packets'] = [unpack_aca_telemetry(a) for a in aca_packets['packets']]
+        for i in range(len(aca_packets['decom_packets'])):
+            for j in range(8):
+                aca_packets['decom_packets'][i][j]['TIME'] = aca_packets['TIME'][i]
+                aca_packets['decom_packets'][i][j]['MJF'] = aca_packets['MJF'][i]
+                aca_packets['decom_packets'][i][j]['MNF'] = aca_packets['MNF'][i]
+                if 'VCDUCTR' in aca_packets:
+                    aca_packets['decom_packets'][i][j]['VCDUCTR'] = aca_packets['VCDUCTR'][i]
+                aca_packets['decom_packets'][i][j]['IMGNUM'] = j
 
-    aca_packets = [[f[i] for f in aca_packets['decom_packets']] for i in range(8)]
+        aca_packets = [[f[i] for f in aca_packets['decom_packets']] for i in range(8)]
+
     if combine:
         aca_packets = sum([[_combine_aca_packets(g) for g in _group_packets(p)]
                            for p in aca_packets], [])
     else:
         aca_packets = [_combine_aca_packets([row]) for slot in aca_packets for row in slot]
-    table = _aca_packets_to_table(aca_packets)
+    table = _aca_packets_to_table(aca_packets, dtype=dtype)
 
     if calibrate:
         for k in ['TEMPCCD', 'TEMPSEC', 'TEMPHOUS', 'TEMPPRIM']:
@@ -817,6 +861,8 @@ def _get_aca_packets(aca_packets, start, stop,
             table['IMG'] = table['IMG'] * table['IMGSCALE'][:, np.newaxis, np.newaxis] / 32 - 50
 
     table = table[(table['TIME'] >= start.secs) * (table['TIME'] < stop.secs)]
+    if dtype:
+        table = table[dtype.names]
     return table
 
 
@@ -826,7 +872,226 @@ def get_aca_images(start, stop, **maude_kwargs):
 
     :param start: timestamp interpreted as a Chandra.Time.DateTime
     :param stop: timestamp interpreted as a Chandra.Time.DateTime
-    :param ``**maude_kwargs``: keyword args passed to maude
+    :param maude_kwargs: keyword args passed to maude
     :return: astropy.table.Table
     """
     return get_aca_packets(start, stop, level0=True, **maude_kwargs)
+
+
+def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
+    """
+    Fetch MAUDE blobs and group them according to the underlying 225-byte ACA packets.
+
+    If the first minor frame in a group of four ACA packets is within (start, stop),
+    the three following minor frames are included if present.
+
+    returns a dictionary with keys ['TIME', 'MNF', 'MJF', 'packets', 'flags'].
+    These correspond to the minor frame time, minor frame count, major frame count,
+    the list of packets, and flags returned by MAUDE respectively.
+
+    This is to blobs what `get_raw_aca_packets` is to frames.
+
+    :param start: timestamp interpreted as a Chandra.Time.DateTime
+    :param stop: timestamp interpreted as a Chandra.Time.DateTime
+    :param maude_result: the result of calling maude.get_blobs. Optional.
+    :param maude_kwargs: keyword args passed to maude.get_frames()
+    :return: dict
+        {'blobs': [], 'names': np.array([]), 'types': np.array([])}
+    """
+    date_start, date_stop = DateTime(start), DateTime(stop)  # ensure input is proper date
+    stop_pad = 1.5 / 86400  # padding at the end in case of trailing partial ACA packets
+
+    if maude_result is None:
+        maude_blobs = maude.get_blobs(start=date_start,
+                                      stop=date_stop + stop_pad,
+                                      **maude_kwargs)
+    else:
+        maude_blobs = maude_result
+
+    aca_block_start = [ACA_SLOT_MSID_LIST[1][3]['sizes'] in [c['n']for c in b['values']]
+                       for b in maude_blobs['blobs']]
+    if not np.any(aca_block_start):
+        maude_blobs['blobs'] = []
+        return maude_blobs
+    maude_blobs['blobs'] = maude_blobs['blobs'][np.argwhere(aca_block_start).min():]
+    if len(maude_blobs['blobs']) % 4:
+        maude_blobs['blobs'] = maude_blobs['blobs'][:-(len(maude_blobs['blobs']) % 4)]
+    for b in maude_blobs['blobs']:
+        b['values'] = {v['n']: v['v'] for v in b['values']}
+
+    merged_blobs = []
+    for i in range(0, len(maude_blobs['blobs']), 4):
+        b = {'time': maude_blobs['blobs'][i]['time']}
+        # blobs are merged in reverse order so the frame counters are the one in the first blob.
+        for j in range(4)[::-1]:
+            b.update(maude_blobs['blobs'][i + j]['values'])
+        merged_blobs.append(b)
+
+    result = {
+        'blobs': [b for b in merged_blobs if b['time'] < date_stop.secs],
+        'names': maude_blobs['names'],
+        'types': maude_blobs['types'],
+    }
+    return result
+
+
+def blob_to_aca_image_dict(blob, imgnum, pea=1):
+    """
+    Assemble ACA image MSIDs from a blob into a dictionary.
+
+    This does to blobs what unpack_aca_telemetry does to frames, but for a single image.
+
+    :param blob:
+    :param imgnum:
+    :param pea:
+    :return:
+    """
+    global_msids = ACA_MSID_LIST[pea]
+    slot_msids = ACA_SLOT_MSID_LIST[pea][imgnum]
+    glbstat_bits = np.unpackbits(np.array(blob[global_msids['status']], dtype=np.uint8))
+    comm_count_bits = np.unpackbits(np.array(blob[global_msids['cmd_count']], dtype=np.uint8))
+    comm_prog_bits = np.unpackbits(np.array(blob[global_msids['cmd_progress']], dtype=np.uint8))
+    result = {
+        'TIME': float(blob['time']),
+        'MJF': int(blob['CVCMJCTR']),
+        'MNF': int(blob['CVCMNCTR']),
+        'VCDUCTR': int(blob['CVCDUCTR']),
+        'IMGNUM': imgnum,
+        'IMGTYPE': int(blob[slot_msids['sizes']]),
+        # 'IMGFID': '1' == blob[slot_msids['fiducial_flag']],
+        # 'IMGNUM': imgnum,
+        # 'IMGFUNC': int(blob[slot_msids['image_function']]),
+        # 'IMGSTAT': int(blob[slot_msids['image_status']]),
+        'pixels': np.array([int(blob[pixel]) for pixel in slot_msids['pixels'] if pixel in blob]),
+        'PIXTLM': 0,  # unused
+        'BGDTYP': 0,  # unused
+        'INTEG': int(blob[global_msids['integration_time']]),
+        'GLBSTAT': int(blob[global_msids['status']]),
+        'HIGH_BGD': bool(glbstat_bits[0]),
+        'RAM_FAIL': bool(glbstat_bits[1]),
+        'ROM_FAIL': bool(glbstat_bits[2]),
+        'POWER_FAIL': bool(glbstat_bits[3]),
+        'CAL_FAIL': bool(glbstat_bits[4]),
+        'COMM_CHECKSUM_FAIL': bool(glbstat_bits[5]),
+        'RESET': bool(glbstat_bits[6]),
+        'SYNTAX_ERROR': bool(glbstat_bits[7]),
+        'COMMCNT': _packbits(comm_count_bits[1:6]),
+        'COMMCNT_SYNTAX_ERROR': comm_count_bits[6],
+        'COMMCNT_CHECKSUM_FAIL': comm_count_bits[7],
+        'COMMPROG': int(blob[global_msids['cmd_progress_to_go']]),
+        'COMMPROG_REPEAT': _packbits(comm_prog_bits[6:8]),
+    }
+
+    if result['IMGTYPE'] in [0, 1, 4]:
+        imgstat_bits = np.array([blob[slot_msids['saturated_pixel']],
+                                 blob[slot_msids['defective_pixel']],
+                                 blob[slot_msids['quad_bound']],
+                                 blob[slot_msids['common_col']],
+                                 blob[slot_msids['multi_star']],
+                                 blob[slot_msids['ion_rad']]]).astype(int)
+        imgstat = int(_packbits(imgstat_bits))
+
+        result.update({
+            'IMGFID': '1' == blob[slot_msids['fiducial_flag']],
+            'IMGNUM': imgnum,
+            'IMGFUNC': int(blob[slot_msids['image_function']]),
+            'IMGSTAT': imgstat,
+            'SAT_PIXEL': bool(int(blob[slot_msids['saturated_pixel']])),
+            'DEF_PIXEL': bool(int(blob[slot_msids['defective_pixel']])),
+            'QUAD_BOUND': bool(int(blob[slot_msids['quad_bound']])),
+            'COMMON_COL': bool(int(blob[slot_msids['common_col']])),
+            'MULTI_STAR': bool(int(blob[slot_msids['multi_star']])),
+            'ION_RAD': bool(int(blob[slot_msids['ion_rad']])),
+            'IMGROW0': int(blob[slot_msids['rows']]),
+            'IMGCOL0': int(blob[slot_msids['cols']]),
+            # 'IMGSCALE': float(blob[slot_msids['scale_factor']]),  # this is scale / 32
+            'IMGSCALE': np.round(float(blob[slot_msids['scale_factor']]) * 32).astype(int),
+            'BGDAVG': int(blob[slot_msids['background_avg']]),
+        })
+
+    if result['IMGTYPE'] in [2, 5]:
+        bgd_stat_pixels = [int(blob[pixel]) for pixel in slot_msids['bgd_stat_pixels']]
+        result.update({
+            'BGDRMS': int(blob[slot_msids['background_rms']]),
+            # 'TEMPCCD': float(blob[slot_msids['ccd_temperature']]),  # this is 0.4 * T
+            # 'TEMPHOUS': float(blob[slot_msids['housing_temperature']]),  # this is 0.4 * T
+            # 'TEMPPRIM': float(blob[slot_msids['primary_temperature']]),  # this is 0.4 * T
+            # 'TEMPSEC': float(blob[slot_msids['secondary_temperature']]),  # this is 0.4 * T
+            'TEMPCCD': np.round(float(blob[slot_msids['ccd_temperature']]) / 0.4).astype(int),
+            'TEMPHOUS': np.round(float(blob[slot_msids['housing_temperature']]) / 0.4).astype(int),
+            'TEMPPRIM': np.round(float(blob[slot_msids['primary_temperature']]) / 0.4).astype(int),
+            'TEMPSEC': np.round(float(blob[slot_msids['secondary_temperature']]) / 0.4).astype(int),
+            'BGDSTAT': int(_packbits(bgd_stat_pixels)),
+            'BGDSTAT_PIXELS': bgd_stat_pixels,
+        })
+    if result['IMGTYPE'] in [6, 7]:
+        result.update({
+            'DIAGNOSTIC': (0, 0, 0, 0, 0, 0)  # not set, and is not used downstream yet.
+        })
+
+    if slot_msids['centroid_ang_y'] in blob:
+        result.update({
+            'YAGS': float(blob[slot_msids['centroid_ang_y']]),
+            'ZAGS': float(blob[slot_msids['centroid_ang_z']])
+        })
+
+    if 'AOATTQT1' in blob:
+        result['AOATTQT1'] = blob['AOATTQT1']
+    if 'AOATTQT2' in blob:
+        result['AOATTQT1'] = blob['AOATTQT2']
+    if 'AOATTQT3' in blob:
+        result['AOATTQT3'] = blob['AOATTQT3']
+    if 'AOATTQT4' in blob:
+        result['AOATTQT4'] = blob['AOATTQT4']
+
+    return result
+
+
+def blobs_to_table(blobs, names, types, msid_offsets=None, **_):
+    """
+    Convenience method to convert raw blobs into an astropy.Table.
+
+    Optionally, some MSIDs can be shifted a fixed number of minor frames.
+    NOTE: If any MSID is shifted, the resulting table is not truncated at the end, which causes the
+    table to have missing MSIDs at the end (since they would be in trailing blobs).
+
+    Example usage::
+
+        >>> from chandra_aca import maude_decom
+        >>> blobs = maude_decom.get_raw_aca_blobs(686111007, 686111009)
+        >>> maude_decom.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
+        <Table length=2>
+             TIME     CVCMJCTR CVCMNCTR
+           float64     uint32   uint8
+        ------------- -------- --------
+        686111007.191     8580       96
+        686111008.216     8580      100
+
+    :param blobs:
+    :param names:
+    :param types:
+    :param msid_offsets:
+    :return:
+    """
+    if not msid_offsets:
+        msid_offsets = {}
+    if len(blobs) and 'values' in blobs[0].keys():
+        values = [{c['n']: c['v'] for c in b['values']} for b in blobs]
+    else:
+        values = blobs
+    t = Table()
+    t['TIME'] = np.array([b['time'] for b in blobs], dtype=types[0])
+    n = len(t)
+    for i in range(1, len(names)):
+        name = names[i]
+        offset = msid_offsets[name] if name in msid_offsets else 0
+        t[name] = MaskedColumn(length=n, dtype=types[i], mask=np.ones(n, dtype=bool))
+        ok = [name in v for v in values]
+        v = np.array([v[name] for v in values if name in v], dtype=types[i])
+        a = np.ma.masked_all([n], dtype=types[i])
+        a[ok] = v
+        if offset:
+            t[name][:-offset] = a[offset:]
+        else:
+            t[name] = a
+    return t

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -548,7 +548,7 @@ ACA_PACKETS_DTYPE = np.dtype(
      ('QUAD_BOUND', np.bool), ('COMMON_COL', np.bool), ('MULTI_STAR', np.bool),
      ('ION_RAD', np.bool), ('IMGROW_A1', np.int16), ('IMGCOL_A1', np.int16),
      ('IMGROW0_8X8', np.int16), ('IMGCOL0_8X8', np.int16), ('END_INTEG_TIME', np.float64),
-     ('PIXTLM', np.uint8), ('BGDTYP', np.uint8)
+     ('PIXTLM', np.uint8), ('BGDTYP', np.uint8), ('IMG', '<f8', (8, 8))
      ]
 )
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -14,6 +14,46 @@ with open(os.path.join(os.path.dirname(__file__), 'data', 'maude_decom.pkl'), 'r
     test_data.update(pickle.load(f))
 
 
+def compare_tables(t1, t2, keys=None, exclude=()):
+    assert len(t1) == len(t2)
+    assert sorted(t1.colnames) == sorted(t2.colnames)
+    _compare_common_columns(t1, t2, keys, exclude)
+
+
+def _compare_common_columns(t1, t2, keys=None, exclude=()):
+    from astropy import table
+
+    if keys is None:
+        keys = [k for k in t1.colnames if k in t2.colnames]
+    for key in exclude:
+        keys.remove(key)
+    errors = []
+    for name in keys:
+        col_1, col_2 = t1[name], t2[name]
+        ok = type(col_1) == type(col_2)
+        if type(col_1) is table.MaskedColumn and type(col_1) is table.MaskedColumn:
+            ok *= np.all(col_1.mask == col_2.mask)
+        if (np.issubdtype(col_1.dtype, np.inexact) or
+                np.issubdtype(col_1.dtype.base, np.inexact)):
+            c = (np.isclose(col_1, col_2) | (np.isnan(col_1) & np.isnan(col_1)))
+        else:
+            c = (col_1 == col_2)
+        if type(col_1) is table.MaskedColumn:
+            if np.sum(~c.mask):
+                ok *= np.all(c[~c.mask])
+        else:
+            ok *= np.all(c)
+        if not ok:
+            errors.append([name, str(col_1.data), str(col_2.data)])
+    if errors:
+        msg = 'The following columns do not match:\n\n'
+        for name, e1, e2 in errors:
+            msg += f'  - {name}\n'
+            msg += f'    t1: {e1}\n'
+            msg += f'    t2: {e2}\n\n'
+        raise Exception(msg)
+
+
 def test_vcdu_0_raw():
     data = maude_decom.get_raw_aca_packets(176267186, 176267186)
     assert data['flags'] == 0
@@ -26,6 +66,19 @@ def test_vcdu_0_raw():
         assert np.all(data[key] == ref_data[key])
     assert data['packets'] == ref_data['packets']
     assert data['flags'] == ref_data['flags']
+
+
+def test_blob_0_raw():
+    blobs = maude_decom.get_raw_aca_blobs(176267186, 176267186)
+    t = maude_decom.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
+    assert len(t) == 0
+
+    ref_data = test_data['686111007-686111017']['raw']
+    blobs = maude_decom.get_raw_aca_blobs(686111007, 686111017)
+    t = maude_decom.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
+    assert np.all(t['TIME'] == ref_data['TIME'])
+    assert np.all(t['CVCMJCTR'] == ref_data['MJF'])
+    assert np.all(t['CVCMNCTR'] == ref_data['MNF'])
 
 
 def test_scale():
@@ -416,3 +469,9 @@ def test_dynbgd_decom():
                     grouped_packets[key]['TIME', 'VCDUCTR', 'IMGTYPE', 'BGDTYP', 'PIXTLM'] ==
                     grouped_packets_2['TIME', 'VCDUCTR', 'IMGTYPE', 'BGDTYP', 'PIXTLM']
                 )
+
+
+def test_get_aca_blobs():
+    t0 = maude_decom.get_aca_packets(686111007, 686111017, frames=True)
+    t1 = maude_decom.get_aca_packets(686111007, 686111017, blobs=True)
+    compare_tables(t0, t1, exclude=['COMMPROG_REPEAT'])

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -5,6 +5,7 @@ import pickle
 import numpy as np
 import pytest
 
+import maude
 from chandra_aca import maude_decom
 
 
@@ -70,12 +71,12 @@ def test_vcdu_0_raw():
 
 def test_blob_0_raw():
     blobs = maude_decom.get_raw_aca_blobs(176267186, 176267186)
-    t = maude_decom.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
+    t = maude.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
     assert len(t) == 0
 
     ref_data = test_data['686111007-686111017']['raw']
     blobs = maude_decom.get_raw_aca_blobs(686111007, 686111017)
-    t = maude_decom.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
+    t = maude.blobs_to_table(**blobs)[['TIME', 'CVCMJCTR', 'CVCMNCTR']]
     assert np.all(t['TIME'] == ref_data['TIME'])
     assert np.all(t['CVCMJCTR'] == ref_data['MJF'])
     assert np.all(t['CVCMNCTR'] == ref_data['MNF'])

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -33,17 +33,17 @@ def _compare_common_columns(t1, t2, keys=None, exclude=()):
         col_1, col_2 = t1[name], t2[name]
         ok = type(col_1) == type(col_2)
         if type(col_1) is table.MaskedColumn and type(col_1) is table.MaskedColumn:
-            ok *= np.all(col_1.mask == col_2.mask)
+            ok &= np.all(col_1.mask == col_2.mask)
         if (np.issubdtype(col_1.dtype, np.inexact) or
                 np.issubdtype(col_1.dtype.base, np.inexact)):
             c = (np.isclose(col_1, col_2) | (np.isnan(col_1) & np.isnan(col_1)))
         else:
             c = (col_1 == col_2)
         if type(col_1) is table.MaskedColumn:
-            if np.sum(~c.mask):
-                ok *= np.all(c[~c.mask])
+            if np.any(~c.mask):
+                ok &= np.all(c[~c.mask])
         else:
-            ok *= np.all(c)
+            ok &= np.all(c)
         if not ok:
             errors.append([name, str(col_1.data), str(col_2.data)])
     if errors:


### PR DESCRIPTION
## Description

This PR adds functionality to fetch ACA data from MAUDE blobs. The main use case is real-time viewing with aca_view (sot/aca_view/pull/65).

This PR adds the following functions to chandra_aca.maude_decom:
- **blob_to_aca_image_dict**. Convert a blob to a dict similar to the output from maude_decom.unpack_aca_telemetry
- **get_raw_aca_blobs**. Get the MAUDE blobs and group them according to the ACA packet (in groups of 4)

It modifies this function:
- **get_aca_packets**. It adds the option to get ACA telemetry from MAUDE using blobs. Does this by calling get_raw_aca_blobs, blob_to_aca_image_dict and then continues in the same way as with binary packets.

It also adds some test functions for the new functionality.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #