### PR TITLE
Planet improvements

### DIFF
--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -189,7 +189,7 @@ def get_planet_chandra_horizons(body, timestart, timestop, n_times=10, timeout=1
         ANG_FORMAT='DEG',
         START_TIME=timestart.datetime.strftime('%Y-%b-%d %H:%M'),
         STOP_TIME=timestop.datetime.strftime('%Y-%b-%d %H:%M'),
-        STEP_SIZE=str(n_times),
+        STEP_SIZE=str(n_times - 1),
         QUANTITIES='1,3,9,13',
         CSV_FORMAT='YES')
 

--- a/chandra_aca/tests/test_planets.py
+++ b/chandra_aca/tests/test_planets.py
@@ -104,7 +104,7 @@ def test_planet_positions_array():
 
 
 def test_get_chandra_planet_horizons():
-    dat = get_planet_chandra_horizons('jupiter', '2020:001', '2020:002')
+    dat = get_planet_chandra_horizons('jupiter', '2020:001', '2020:002', n_times=11)
     exp = ['         time             ra       dec     rate_ra    rate_dec   mag  '
            '    surf_brt   ang_diam',
            '                         deg       deg    arcsec / h arcsec / h  mag  '


### PR DESCRIPTION
## Description

This includes a few improvements related to handling planets. 

- Allow computing light travel from Chandra not Earth
- Make n_times be actual number of times
- Add `get_planet_angular_sep()` function. This will be useful in starcheck and potentially sparkles if we add planet checks.
- Always plot planets if near FOV and add legend.

The most evident is the change in plotting to always show planets if they are in the FOV. For instance the sparkles plot for 23368 in JUL1921 prelim looks like below. Sparkles does not have an obs duration so this just reflects the start time, but still this makes noticing a planet much easier.

<img src="https://user-images.githubusercontent.com/348089/124806029-3bcf6480-df2a-11eb-9413-9fe14d4e04a9.png" width=400>


## Testing

- [x] Passes unit tests on MacOS (including new unit tests)
- [x] Functional testing
### Functional testing

As shown in plot above, ran sparkles on a load with a planet and saw expected result. 

Also this script demonstrates plotting a star field where Venus is in the FOV. This is not a realistic observation.
```
from chandra_aca.plot import plot_stars
from chandra_aca.transform import *
from chandra_aca.plot import *
%matplotlib
from chandra_aca.planets import *
eci = get_planet_chandra('venus', '2020:001')
ra, dec = eci_to_radec(eci)
plot_stars(starcat_time='2020:001', duration=10000, attitude=[ra, dec, 0])
```
<img src="https://user-images.githubusercontent.com/348089/124807079-65d55680-df2b-11eb-8cd7-4fe172b6d95d.png" width=400>
