### PR TITLE
Fix bug where centroid_fm was modifying input image

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -572,8 +572,12 @@ def _prep_6x6(img, bgd=None):
     if isinstance(bgd, np.ndarray):
         bgd = bgd.view(np.ndarray)
 
+    # Subtract background and/or ensure a copy of img is made since downstream
+    # code may modify the image.
     if bgd is not None:
         img = img - bgd
+    else:
+        img = img.copy()
 
     if img.shape == (8, 8):
         img = img[1:7, 1:7]

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -137,20 +137,24 @@ def test_fm_centroid():
     img = np.zeros((6, 6), dtype=float)
     img[0, 0] = 1000  # Should be ignored by mouse-bite
     img[2, 2] = 100
+    img_orig = img.copy()
     row, col, norm = centroid_fm(img)
     assert np.isclose(row, 2.0)
     assert np.isclose(col, 2.0)
     assert np.isclose(norm, 100)
+    assert np.all(img == img_orig)
 
     # 8x8 image with background of 10
     img = np.zeros((8, 8), dtype=float) + 10
     img[0, 0] = 1000  # Should be ignored by mouse-bite
     img[1, 1] = 1000  # Should be ignored by mouse-bite
     img[3, 3] = 100
+    img_orig = img.copy()
     row, col, norm = centroid_fm(img, bgd=10)
     assert np.isclose(row, 3.0)
     assert np.isclose(col, 3.0)
     assert np.isclose(norm, 90)
+    assert np.all(img == img_orig)
 
     # Check 'edge' coordinates
     row, col, norm = centroid_fm(img, bgd=10, pix_zero_loc='edge')


### PR DESCRIPTION
## Description

`Centroid_fm` (via `_prep_6x6` inherited from annie_) was modifying the input image in place when no background was supplied.

## Testing

- [x] Passes unit tests on MacOS (with updated test to specifically test the change)
- [n/a] Functional testing

Without the patch the updated test fails as expected.