### PR TITLE
Allow for broadcastable array inputs in snr_mag_for_t_ccd and guide_count

### DIFF
--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -117,6 +117,20 @@ def test_t_ccd_warm_limit_guide():
 
 
 @pytest.mark.parametrize('count_9th', [False, True])
+def test_guide_count_t_ccd_array(count_9th):
+    mags0 = np.linspace(8.5, 9.75, 6)
+    mags1 = np.linspace(9.75, 10.0, 2)
+    t_ccd0 = -5.0
+    t_ccd1 = -9.0
+    count0 = guide_count(t_ccd=t_ccd0, mags=mags0, count_9th=count_9th)
+    count1 = guide_count(t_ccd=t_ccd1, mags=mags1, count_9th=count_9th)
+    count = guide_count(t_ccd=np.concatenate([[t_ccd0] * 6, [t_ccd1] * 2]),
+                        mags=np.concatenate([mags0, mags1]),
+                        count_9th=count_9th)
+    assert np.isclose(count0 + count1, count, atol=1e-6, rtol=0)
+
+
+@pytest.mark.parametrize('count_9th', [False, True])
 def test_guide_count(count_9th):
     """Test fractional guide count"""
 

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -330,27 +330,32 @@ def snr_mag_for_t_ccd(t_ccd, ref_mag, ref_t_ccd, scale_4c=None):
     If scale_4c is None, the value from dark_model.DARK_SCALE_4C is used.
 
     To solve for the magnitude that has the expected signal to noise as
-    ref_mag / ref_t_ccd, we define this equality:
+    ref_mag / ref_t_ccd, we use the following derivation::
 
-    counts(mag) / noise(t_ccd) = counts(ref_mag) / noise(ref_t_ccd)
+      counts(mag) / noise(t_ccd) = counts(ref_mag) / noise(ref_t_ccd)
+      noise(t_ccd) = noise(ref_t_ccd) * scale
+      scale = scale_4c ** ((t_ccd - ref_t_ccd) / 4.0)
 
-    We then assume (with some handwaving) that:
+    Using the definition of counts as a function of magnitude, substituting in,
+    reducing, and solving the original equality for mag gives::
 
-    noise(t_ccd) = noise(ref_t_ccd) * scale
+      counts(mag) = ACA_CNT_RATE_MAG0 * 10.0 ** ((ACA_MAG0 - mag) / 2.5)
+      ref_mag = (t_ccd - ref_t_ccd) * np.log10(scale_4c) / 1.6
 
-    where
-
-    scale = scale_4c ** ((t_ccd - ref_t_ccd) / 4.0)
-
-    And we use the definition of counts as:
-
-    counts(mag) = ACA_CNT_RATE_MAG0 * 10.0 ** ((ACA_MAG0 - mag) / 2.5)
-
-    Substituting in, reducing, and solving the original equality for mag gives
-
-    ref_mag - (t_ccd - ref_t_ccd) * np.log10(scale_4c) / 1.6
-
+    :param t_ccd: float, array
+        CCD temperature (degC)
+    :param ref_mag: float, array
+        Reference magnitude (mag)
+    :param ref_t_ccd: float, array
+        Reference CCD temperature (degC)
+    :param scale_4c: float
+        Scale factor for a 4 degC change in CCD temperature (defaults to DARK_SCALE_4C)
+    :returns: float, array
+        Magnitude(s) with the same expected signal to noise as ref_mag at ref_t_ccd
     """
+    # Allow array inputs
+    t_ccd, ref_mag, ref_t_ccd = np.broadcast_arrays(t_ccd, ref_mag, ref_t_ccd)
+
     if scale_4c is None:
         scale_4c = dark_model.DARK_SCALE_4C
     return ref_mag - (t_ccd - ref_t_ccd) * np.log10(scale_4c) / 1.6


### PR DESCRIPTION
## Description

Make the inputs to `snr_mag_for_t_ccd` and `guide_count` a bit more general in allowing array inputs that are broadcast with each other.

While in the code I tidied the doc strings a bit.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

The API is more general now but fully back-compatible.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac with a new unit test

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Using this branch, both `proseco` and `sparkles` also pass their unit tests, so there are no regressions introduced by the change in this PR.
