### PR TITLE
add AOKALSTR, AOPCADMD, AOACASEQ when fetching blobs

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -940,6 +940,21 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
     return result
 
 
+def get_state_codes(msid):
+    import Ska.tdb
+    try:
+        states = Ska.tdb.msids[msid].Tsc
+    except Exception:
+        return {}
+    else:
+        if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
+            return {}
+        states = np.sort(states.data, order='LOW_RAW_COUNT')
+        return dict([
+            (state['LOW_RAW_COUNT'], state['STATE_CODE']) for state in states
+        ])
+
+
 def blob_to_aca_image_dict(blob, imgnum, pea=1):
     """
     Assemble ACA image MSIDs from a blob into a dictionary.
@@ -960,6 +975,9 @@ def blob_to_aca_image_dict(blob, imgnum, pea=1):
         'TIME': float(blob['time']),
         'MJF': int(blob['CVCMJCTR']),
         'MNF': int(blob['CVCMNCTR']),
+        'AOKALSTR': int(blob['AOKALSTR']),
+        'AOPCADMD': get_state_codes('AOPCADMD')[int(blob['AOPCADMD'])],
+        'AOACASEQ': get_state_codes('AOACASEQ')[int(blob['AOACASEQ'])],
         'VCDUCTR': int(blob['CVCDUCTR']),
         'IMGNUM': imgnum,
         'IMGTYPE': int(blob[slot_msids['sizes']]),

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -940,21 +940,6 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
     return result
 
 
-def get_state_codes(msid):
-    import Ska.tdb
-    try:
-        states = Ska.tdb.msids[msid].Tsc
-    except Exception:
-        return {}
-    else:
-        if states is None or len(set(states['CALIBRATION_SET_NUM'])) != 1:
-            return {}
-        states = np.sort(states.data, order='LOW_RAW_COUNT')
-        return dict([
-            (state['LOW_RAW_COUNT'], state['STATE_CODE']) for state in states
-        ])
-
-
 def blob_to_aca_image_dict(blob, imgnum, pea=1):
     """
     Assemble ACA image MSIDs from a blob into a dictionary.
@@ -976,8 +961,8 @@ def blob_to_aca_image_dict(blob, imgnum, pea=1):
         'MJF': int(blob['CVCMJCTR']),
         'MNF': int(blob['CVCMNCTR']),
         'AOKALSTR': int(blob['AOKALSTR']),
-        'AOPCADMD': get_state_codes('AOPCADMD')[int(blob['AOPCADMD'])],
-        'AOACASEQ': get_state_codes('AOACASEQ')[int(blob['AOACASEQ'])],
+        'AOPCADMD': maude.STATE_CODES['AOPCADMD'][int(blob['AOPCADMD'])],
+        'AOACASEQ': maude.STATE_CODES['AOACASEQ'][int(blob['AOACASEQ'])],
         'VCDUCTR': int(blob['CVCDUCTR']),
         'IMGNUM': imgnum,
         'IMGTYPE': int(blob[slot_msids['sizes']]),

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -245,7 +245,8 @@ def test_get_aimpoint():
         assert chipx == answer[0]
         assert chipy == answer[1]
         assert chip_id == answer[2]
-    zot = Table.read("""date_effective  cycle_effective  detector  chipx   chipy   chip_id  obsvis_cal
+    zot = Table.read(
+        """date_effective  cycle_effective  detector  chipx   chipy   chip_id  obsvis_cal
 2012-12-15      15               ACIS-I    888   999   -1        1.6""", format='ascii')
     chipx, chipy, chip_id = drift.get_target_aimpoint(
         '2016-08-22', 15, 'ACIS-I', zero_offset_table=zot)


### PR DESCRIPTION
## Description

These are minimal changes to add AOKALSTR, AOPCADMD, AOACASEQ when fetching blobs. Note that these MSIDS are still not fetched when fetching VCDU frames.

I also added a `get_state_codes` function, more or less what cheta does, to convert AOPCADMD, AOACASEQ status codes to standard human-readable strings.

## Interface impacts
None

## Testing


### Unit tests

- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

Test were done in [chandra_aca/pull/126](https://github.com/sot/chandra_aca/pull/126)
