### PR TITLE
Fixed maude_decom to work on real-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,116 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# emacs
+*~
+
+# Mac OS
+.DS_Store
+
+# other
+.idea
+.vscodebuild
+record.txt
+.vscode

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -788,7 +788,7 @@ def get_aca_packets(start, stop, level0=False,
         aca_data = vstack(aca_packets)
     else:
         maude_result = blobs if (type(blobs) is dict and 'blobs' in blobs) else None
-        merged_blobs = get_raw_aca_blobs(date_start, date_stop,
+        merged_blobs = get_raw_aca_blobs(date_start, date_stop + stop_pad,
                                          maude_result=maude_result,
                                          **maude_kwargs)['blobs']
         aca_packets = [[blob_to_aca_image_dict(b, i) for b in merged_blobs] for i in range(8)]
@@ -796,6 +796,7 @@ def get_aca_packets(start, stop, level0=False,
                                     combine=combine, adjust_time=adjust_time, calibrate=calibrate,
                                     blobs=True,
                                     dtype=dtype)
+        aca_data = aca_data[(aca_data['TIME'] >= start) & (aca_data['TIME'] < stop)]
     return aca_data
 
 

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -446,9 +446,9 @@ def _group_packets(packets, discard=True):
             res = []
         if not res:
             # the number of minor frames expected within the same ACA packet
-            s = {0: 1, 1: 2, 2: 2, 4: 4, 5: 4, 6: 4, 7: 4}[packet['IMGTYPE']]
+            s = {0: 1, 1: 2, 2: 2, 4: 4, 5: 4, 6: 4, 7: 4}[int(packet['IMGTYPE'])]
             # the number of minor frames within the same ACA packet expected after this minor frame
-            remaining = {0: 0, 1: 1, 2: 0, 4: 3, 5: 2, 6: 1, 7: 0}[packet['IMGTYPE']]
+            remaining = {0: 0, 1: 1, 2: 0, 4: 3, 5: 2, 6: 1, 7: 0}[int(packet['IMGTYPE'])]
             n = packet['MJF'] * 128 + packet['MNF'] + 4 * remaining
         res.append(packet)
     if res and (not discard or len(res) == s):

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -852,10 +852,12 @@ def _get_aca_packets(aca_packets, start, stop,
     table['IMGROW0'][table['IMGTYPE'] == 2] -= 1
     table['IMGCOL0'][table['IMGTYPE'] == 2] -= 1
 
+    table['INTEG'] = table['INTEG'] * 0.016
+    table['END_INTEG_TIME'] = table['TIME'] + table['INTEG']
     if adjust_time:
-        table['INTEG'] = table['INTEG'] * 0.016
-        table['TIME'] -= table['INTEG'] / 2 + 1.025
-        table['END_INTEG_TIME'] = table['TIME'] + table['INTEG'] / 2
+        dt = table['INTEG'] / 2 + 1.025
+        table['TIME'] -= dt
+        table['END_INTEG_TIME'] -= dt
 
     if calibrate:
         if 'IMG' in table.colnames:

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -776,7 +776,7 @@ def get_aca_packets(start, stop, level0=False,
         batches = [(date_start + i * dt, date_start + (i + 1) * dt) for i in range(n)]  # 0.0001????
         aca_packets = []
         for t1, t2 in batches:
-            maude_result = frames if type(frames) is dict and 'data' in frames else None
+            maude_result = frames if (type(frames) is dict and 'data' in frames) else None
             raw_aca_packets = get_raw_aca_packets(t1, t2 + stop_pad,
                                                   maude_result=maude_result,
                                                   **maude_kwargs)
@@ -787,7 +787,7 @@ def get_aca_packets(start, stop, level0=False,
             aca_packets.append(packets)
         aca_data = vstack(aca_packets)
     else:
-        maude_result = frames if type(frames) is dict and 'data' in frames else None
+        maude_result = blobs if (type(blobs) is dict and 'blobs' in blobs) else None
         merged_blobs = get_raw_aca_blobs(date_start, date_stop,
                                          maude_result=maude_result,
                                          **maude_kwargs)['blobs']

--- a/chandra_aca/tests/test_all.py
+++ b/chandra_aca/tests/test_all.py
@@ -245,7 +245,8 @@ def test_get_aimpoint():
         assert chipx == answer[0]
         assert chipy == answer[1]
         assert chip_id == answer[2]
-    zot = Table.read("""date_effective  cycle_effective  detector  chipx   chipy   chip_id  obsvis_cal
+    zot = Table.read(
+        """date_effective  cycle_effective  detector  chipx   chipy   chip_id  obsvis_cal
 2012-12-15      15               ACIS-I    888   999   -1        1.6""", format='ascii')
     chipx, chipy, chip_id = drift.get_target_aimpoint(
         '2016-08-22', 15, 'ACIS-I', zero_offset_table=zot)

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -480,3 +480,40 @@ def test_get_aca_blobs():
     t0 = maude_decom.get_aca_packets(686111007, 686111017, frames=True)
     t1 = maude_decom.get_aca_packets(686111007, 686111017, blobs=True)
     compare_tables(t0, t1, exclude=['COMMPROG_REPEAT'])
+
+
+def test_blob_frame_consistency():
+    slot = 6
+    start, stop = (686111012., 686111212.)
+    slot_data = maude_decom.get_aca_packets(
+        start, stop, level0=True, blobs=False,
+    )
+    slot_data_2 = maude_decom.get_aca_packets(
+        start, stop, level0=True, blobs=True,
+    )
+    slot_data = slot_data[slot_data['IMGNUM'] == slot]
+    slot_data_2 = slot_data_2[slot_data_2['IMGNUM'] == slot]
+    assert len(slot_data) == len(slot_data_2)
+
+
+def test_get_aca_packets_blobs():
+    # this test indirectly checks that the blobs argument in get_aca_packets is used
+    # because the blobs correspond to a shorter interval and therefore the should match
+    # the result from the shorter interval
+    slot = 6
+    start, stop = (686111012., 686111111.)
+    slot_data = maude_decom.get_aca_packets(
+        start, stop, level0=True, blobs=True,
+    )
+    blobs = maude.get_blobs(
+        start=start,
+        stop=stop + 4,
+        channel='FLIGHT',
+    )
+    start, stop = (686111012., 686111212.)
+    slot_data_2 = maude_decom.get_aca_packets(
+        start, stop, level0=True, blobs=blobs,
+    )
+    slot_data = slot_data[slot_data['IMGNUM'] == slot]
+    slot_data_2 = slot_data_2[slot_data_2['IMGNUM'] == slot]
+    assert len(slot_data) == len(slot_data_2)


### PR DESCRIPTION
## Description

This makes the following changes:
- cast `packet['IMGTYPE']` as int in _group_packets (it was a string in real-time)
- the `blobs` argument to `get_aca_packets` was ignored. Fixed.
- the result of `get_aca_packets` did not include the `INTEG` and `END_INTEG_TIME ` columns if the times were not shifted to match level0 times (shifting times used to be the default in aca_view until now).

Fixes #127 

## Interface impacts
None

## Testing

### Unit tests

- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
No functional testing.
