### PR TITLE
Bugfix: make sure maude_result argument to get_raw_aca_blobs is not modified inside the function

### DIFF
--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import numpy as np
 import pytest
+import copy
 
 import maude
 from chandra_aca import maude_decom
@@ -517,3 +518,10 @@ def test_get_aca_packets_blobs():
     slot_data = slot_data[slot_data['IMGNUM'] == slot]
     slot_data_2 = slot_data_2[slot_data_2['IMGNUM'] == slot]
     assert len(slot_data) == len(slot_data_2)
+
+    # calling the function again with the same blobs (they should not have been modified)
+    ref_blobs = copy.deepcopy(blobs)
+    slot_data_2 = maude_decom.get_aca_packets(
+        start, stop, level0=True, blobs=blobs,
+    )
+    assert blobs == ref_blobs


### PR DESCRIPTION
## Description

Unfortunately, I found yet another issue with blobs in maude_decom. This issue does not affect anything I have done up to now.

The `maude_decom.get_raw_aca_blobs` takes a `maude_result` argument, which contains the blobs as returned by maude, and this object is (inadvertently) modified inside the function. As a result, if one tries to use the blobs after calling this function, the data structure has changed and this causes errors. I would prefer to keep the argument unchanged, because whatever changes the function made are implementation details.

One could argue that the modified blobs are a better, because each blob's values are transformed from a list to a dictionary, which is better to fish out specific MSIDs. Namely, the master version does the following:
```
for b in maude_blobs['blobs']:
    b['values'] = {v['n']: v['v'] for v in b['values']}
```
although I think this is better as it does not loose information:
```
for b in maude_blobs['blobs']:
    b['values'] = {v['n']: v for v in b['values']}
```

If we prefer to modify the blobs, then the modification should be done in a separate function, perhaps in maude, and not as a side effect of any function, so I think this qualifies as a bug in any case.

## Interface impacts
None

## Testing

### Unit tests
This PR has two commits. In the first commit I add a new test which fails and is fixed by the second commit.

- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

No functional testing.
