### PR TITLE
fix in maude_decom.get_aca_packets from blobs

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -192,9 +192,10 @@ def _aca_image_msid_list(pea):
 
         'image_status': [f'AOIMAGE{i}' for i in range(8)],    # IMAGE STATUS FLAG
         'fiducial_flag': [f'AOACFID{i}' for i in range(8)],  # FIDUCIAL LIGHT FLAG (OBC)
-        'image_function': [f'AOACFCT{i}' for i in range(8)],  # IMAGE FUNCTION (OBC)
+        'image_function_obc': [f'AOACFCT{i}' for i in range(8)],  # IMAGE FUNCTION (OBC)
+        'image_function': [f'{msid_prefix}AIMGF{i}1' for i in range(8)],  # IMAGE FUNCTION (PEA)
         # this one exists also as FUNCTION2/3/4
-        # 'image_function_pea':
+        # 'image_function':
         #     [f'{msid_prefix}AIMGF{i}1' for i in range(8)],  # IMAGE FUNCTION1 (PEA)
 
         'saturated_pixel': [f'{msid_prefix}ASPXF{i}' for i in range(8)],  # DEFECTIVE PIXEL FLAG

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -495,6 +495,12 @@ def test_blob_frame_consistency():
     slot_data = slot_data[slot_data['IMGNUM'] == slot]
     slot_data_2 = slot_data_2[slot_data_2['IMGNUM'] == slot]
     assert len(slot_data) == len(slot_data_2)
+    compare_tables(slot_data, slot_data_2, exclude=['COMMPROG_REPEAT'])
+
+    start, stop = 686105735.6057751, 686105740.7507753
+    slot_data = maude_decom.get_aca_packets(start, stop, blobs=False)
+    slot_data_blobs = maude_decom.get_aca_packets(start, stop, blobs=True)
+    compare_tables(slot_data, slot_data_blobs, exclude=['COMMPROG_REPEAT'])
 
 
 def test_get_aca_packets_blobs():


### PR DESCRIPTION
## Description

This is a trivial change in maude_decom.

When calling get_aca_packets using blobs, it currently sets the image function from `AOACFCT{slot}`, which is the MSID for the image function in the OBC. After this PR, it will set it from `{pea_prefix}AIMGF{slot}1`.

One reason to keep the OBC value is that it is sampled **much** more often, but then it does not match the image shown, so this can cause confusion. I do not remember if we explicitly decided to keep that one. If wed wanted that, I still think this is not the place to do it (because this is all about ACA packets).

Another option is to not have a single image function, but include all four instances of IMGFUN found in ACA telemetry.

## Interface impacts
None

## Testing
Unit tests pass, including a new test that would fail in current master.

### Unit tests
- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
No functional testing.
