### PR TITLE
Modernize

### DIFF
--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -360,12 +360,17 @@ def get_planet_chandra_horizons(
 
     if resp.status_code != requests.codes["ok"]:
         raise ValueError(
-            "request {resp.url} failed: {resp.reason} ({resp.status_code})"
+            f"request {resp.url} failed: {resp.reason} ({resp.status_code})"
         )
 
     resp_json: dict = resp.json()
     result: str = resp_json["result"]
     lines = result.splitlines()
+
+    if "$$SOE" not in lines:
+        msg = "problem with Horizons query:\n" + "\n".join(lines)
+        raise ValueError(msg)
+
     idx0 = lines.index("$$SOE") + 1
     idx1 = lines.index("$$EOE")
     lines = lines[idx0:idx1]
@@ -386,6 +391,7 @@ def get_planet_chandra_horizons(
             "ang_diam",
             "null3",
         ],
+        fill_values=[("n.a.", "0")],
     )
 
     times = [datetime.strptime(val[:20], "%Y-%b-%d %H:%M:%S") for val in dat["time"]]

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -319,11 +319,9 @@ def get_planet_chandra_horizons(body, timestart, timestop, n_times=10, timeout=1
         "uranus": "799",
         "neptune": "899",
     }
-    if body not in planet_ids:
-        raise ValueError(f"body must be one of {tuple(planet_ids)}")
 
     params = dict(
-        COMMAND=planet_ids[body],
+        COMMAND=planet_ids.get(body, str(body).lower()),
         MAKE_EPHEM="YES",
         CENTER="@-151",
         TABLE_TYPE="OBSERVER",

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -22,12 +22,13 @@ See the ``validation/planet-accuracy.ipynb`` notebook for details.
 """
 from datetime import datetime
 from pathlib import Path
+from typing import Optional, Union
 
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
 from astropy.io import ascii
-from cxotime import CxoTime
+from cxotime import CxoTime, CxoTimeLike
 from ska_helpers.utils import LazyVal
 
 from chandra_aca.transform import eci_to_radec
@@ -153,10 +154,13 @@ def get_planet_angular_sep(
     return sep
 
 
-def get_planet_barycentric(body, time=None):
+def get_planet_barycentric(body: str, time: CxoTimeLike = None):
     """Get barycentric position for solar system ``body`` at ``time``.
 
     This uses the built-in JPL ephemeris file DE432s and jplephem.
+
+    ``body`` must be one of "sun", "mercury", "venus", "earth-moon-barycenter", "earth",
+    "moon", "mars", "jupiter", "saturn", "uranus", "neptune", or "pluto".
 
     :param body: Body name (lower case planet name)
     :param time: Time or times for returned position (default=NOW)
@@ -178,12 +182,18 @@ def get_planet_barycentric(body, time=None):
     return pos.transpose()  # SPK returns (3, N) but we need (N, 3)
 
 
-def get_planet_eci(body, time=None, pos_observer=None):
+def get_planet_eci(
+    body: str, time: CxoTimeLike = None, pos_observer: Optional[str] = None
+):
     """Get ECI apparent position for solar system ``body`` at ``time``.
 
     This uses the built-in JPL ephemeris file DE432s and jplephem. The position
     is computed at the supplied ``time`` minus the light-travel time from the
     observer to ``body`` to generate the apparent position on Earth at ``time``.
+
+    ``body`` and ``pos_observer`` must be one of "sun", "mercury", "venus",
+    "earth-moon-barycenter", "earth", "moon", "mars", "jupiter", "saturn", "uranus",
+    "neptune", or "pluto".
 
     Estimated accuracy of planet coordinates (RA, Dec) is as follows, where the
     JPL Horizons positions are used as the "truth". This assumes the observer
@@ -214,7 +224,7 @@ def get_planet_eci(body, time=None, pos_observer=None):
     return pos_planet - pos_observer
 
 
-def get_planet_chandra(body, time=None):
+def get_planet_chandra(body: str, time: CxoTimeLike = None):
     """Get position for solar system ``body`` at ``time`` relative to Chandra.
 
     This uses the built-in JPL ephemeris file DE432s and jplephem, along with
@@ -267,11 +277,20 @@ def get_planet_chandra(body, time=None):
     return planet_chandra
 
 
-def get_planet_chandra_horizons(body, timestart, timestop, n_times=10, timeout=10):
-    """Get body position, rate, mag, surface brightness, diameter from Horizons.
+def get_planet_chandra_horizons(
+    body: Union[str, int],
+    timestart: CxoTimeLike,
+    timestop: CxoTimeLike,
+    n_times: int = 10,
+    timeout: float = 10,
+):
+    """Get body position and other info as seen from Chandra using JPL Horizons.
 
-    This function queries the JPL Horizons site using the CGI batch interface
-    (See https://ssd.jpl.nasa.gov/horizons_batch.cgi for docs).
+    In addition to the planet names, the ``body`` argument can be any identifier that
+    Horizon supports, e.g. ``sun`` or ``geo`` (Earth geocenter).
+
+    This function queries the JPL Horizons site using the web API interface
+    (See https://ssd-api.jpl.nasa.gov/doc/horizons.html for docs).
 
     The return value is an astropy Table with columns: time, ra, dec, rate_ra,
     rate_dec, mag, surf_brt, ang_diam. The units are included in the table
@@ -297,7 +316,7 @@ def get_planet_chandra_horizons(body, timestart, timestop, n_times=10, timeout=1
       2020:002:00:00:00.000 277.21454 -23.18970      34.69       2.51  -1.839         5.408    31.76
 
     :param body: one of 'mercury', 'venus', 'mars', 'jupiter', 'saturn',
-        'uranus', 'neptune'
+        'uranus', 'neptune', or any other body that Horizons supports.
     :param timestart: start time (any CxoTime-compatible time)
     :param timestop: stop time (any CxoTime-compatible time)
     :param n_times: number of time samples (inclusive, default=10)

--- a/chandra_aca/tests/test_planets.py
+++ b/chandra_aca/tests/test_planets.py
@@ -114,8 +114,9 @@ def test_planet_positions_array():
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
-def test_get_chandra_planet_horizons():
-    dat = get_planet_chandra_horizons("jupiter", "2020:001", "2020:002", n_times=11)
+@pytest.mark.parametrize("body", ["jupiter", 599])
+def test_get_chandra_planet_horizons(body):
+    dat = get_planet_chandra_horizons(body, "2020:001", "2020:002", n_times=11)
     exp = [
         "         time             ra       dec     rate_ra    rate_dec   mag  "
         "    surf_brt   ang_diam",
@@ -147,6 +148,22 @@ def test_get_chandra_planet_horizons():
         "         5.408    31.76",
     ]
 
+    assert dat.pformat_all() == exp
+
+
+@pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
+def test_get_chandra_planet_horizons_non_planet():
+    dat = get_planet_chandra_horizons(
+        "ACE (spacecraft)", "2020:001", "2020:002", n_times=2
+    )
+    exp = [
+        "    ra       dec     rate_ra    rate_dec  mag    surf_brt   ang_diam",
+        "   deg       deg    arcsec / h arcsec / h mag mag / arcsec2  arcsec ",
+        "--------- --------- ---------- ---------- --- ------------- --------",
+        "274.14524 -24.72559      10.75    -325.04  --            --       --",
+        "275.29375 -23.83915     349.43     659.97  --            --       --",
+    ]
+    del dat["time"]
     assert dat.pformat_all() == exp
 
 


### PR DESCRIPTION
## Description

This removes an unnecessary limitation that the `body` provided to `get_planet_chandra_horizons` needed to be a planet. In fact any allowed Horizons body name or integer identifier is fine here. The function name is unfortunate since `body` can be anything now.

I also discovered that the previous CGI web interface is deprecated in favor of a new proper web API interface, so this migrates to that new interface.

For the key functions in the `planets` module this adds type annotations.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None except expands the capability of `get_planet_chandra_horizons`.

## Testing
<!-- If relevant describe any special setup for testing. -->
Requires https://github.com/sot/cxotime/pull/31 

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean 
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
