### PR TITLE
Update pre-commit hooks and black workflow to latest versions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,10 +1,10 @@
 name: Check black formatting
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
     - id: black
       language_version: python3.8
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: v5.11.3
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
## Description

This updates the pre-commit hooks for black and isort to use the latest releases. Not that crucial but I just wanted to test the [pre-commit autoupdate](https://pre-commit.com/#pre-commit-autoupdate) machinery.

I also noticed that the black workflow is running on `push` and `pull-request` and this seems to run twice for the initial pull request. So I just changed it to run on `push`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->
No code changes. The update occurred as expected and was reflected in the commit for this change.
