### PR TITLE
Performance improvements for planets

### DIFF
--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -27,8 +27,7 @@ from typing import Optional, Union
 import astropy.units as u
 import numpy as np
 from astropy.io import ascii
-from Chandra.Time import DateTime
-from cxotime import CxoTime, CxoTimeLike
+from cxotime import CxoTime, CxoTimeLike, convert_time_format
 from ska_helpers.utils import LazyVal
 
 from chandra_aca.transform import eci_to_radec
@@ -141,7 +140,7 @@ def get_planet_angular_sep(
         eci = get_planet_chandra(body, time)
         body_ra, body_dec = eci_to_radec(eci)
     elif observer_position == "chandra-horizons":
-        time_secs = CxoTime(time).secs
+        time_secs = convert_time_format(time, "secs")
 
         if time_secs.shape == ():
             time_secs = [time_secs, time_secs + 1000]
@@ -192,9 +191,7 @@ def get_planet_barycentric(body: str, time: CxoTimeLike = None):
         )
 
     spk_pairs = BODY_NAME_TO_KERNEL_SPEC[body]
-    # NOTE: DateTime(time).jd is about 10 times faster than CxoTime(time).jd.
-    # TODO: Use a faster built-in from cxotime when available.
-    time_jd = DateTime(time).jd
+    time_jd = convert_time_format(time, "jd")
     pos = kernel[spk_pairs[0]].compute(time_jd)
     for spk_pair in spk_pairs[1:]:
         pos += kernel[spk_pair].compute(time_jd)
@@ -239,7 +236,7 @@ def get_planet_eci(
         Earth-Centered Inertial (ECI) position (km) as (x, y, z)
         or N x (x, y, z)
     """
-    time_sec = DateTime(time).secs
+    time_sec = convert_time_format(time, "secs")
 
     pos_planet = get_planet_barycentric(body, time_sec)
     if pos_observer is None:

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -319,6 +319,8 @@ def test_vcdu_vs_level0():
             os.path.join(
                 os.path.dirname(__file__), "data", f"test_level0_{slot}.fits.gz"
             ),
+            # Undocumented way to stop UnitsWarning 'DN' did not parse warning. See
+            # https://github.com/astropy/astropy/issues/14330#issuecomment-1406538512
             unit_parse_strict="silent",
         )
         td = l0_test_data[


### PR DESCRIPTION
## Description

This is part of the changes to kadi, chandra_aca, ska_sun, Quaternion, and Chandra.Maneuver to make kadi command states faster.

This change is to use `convert_time_format` in place of `CxoTime` or `DateTime`. Some slight re-ordering of code logic was needed but the changes should be fairly understandable.

This PR also avoids using astropy units in this context. While units are nice and elegant, regular floats / np.arrays are much faster.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests

#### Functional performance improvements
About a factor of two for these cases.

Setup:
```
>>> from chandra_aca.planets import get_planet_eci, get_planet_angular_sep
>>> from cxotime import CxoTime
>>> times = CxoTime("2023:001").secs + np.linspace(0, 1000, 100)
```
Flight:
```
>>> %timeit dat = get_planet_eci("mars", times)
823 µs ± 15.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
>>> %timeit  get_planet_angular_sep("mars", time=times, ra=0, dec=1)
860 µs ± 4.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
PR:
```
>>> %timeit get_planet_eci("mars", times)
414 µs ± 2.94 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
>>> %timeit  get_planet_angular_sep("mars", time=times, ra=0, dec=1)
430 µs ± 1.27 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```



<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### convert_time_format() reference
For reference, here are timing comparisons showing that `convert_time_format` is indeed faster than `DateTime` for common cases:
```
In [1]: from Chandra.Time import DateTime

In [2]: from cxotime import convert_time_format, CxoTime

In [3]: %timeit DateTime(100.0).jd
9.26 µs ± 84.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: timeit convert_time_format(100.0, "jd")
4.54 µs ± 27 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [5]: %timeit DateTime("2023:001:01:01:01.000").jd
16.4 µs ± 76.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [6]: %timeit convert_time_format("2023:001:01:01:01.000", "jd")
10.1 µs ± 1.3 µs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

