### PR TITLE
Remove deprecated decorator and six dependency

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import numba
 import numpy as np
-import six
-from astropy.utils.compat.misc import override__dir__
-from six.moves import zip
 
 __all__ = ["ACAImage", "centroid_fm", "AcaPsfLibrary", "EIGHT_LABELS"]
 
@@ -174,8 +171,6 @@ class ACAImage(np.ndarray):
     __add__ = _operator_factory("add")
     __sub__ = _operator_factory("sub")
     __mul__ = _operator_factory("mul")
-    if not six.PY3:
-        __div__ = _operator_factory("div")
     __truediv__ = _operator_factory("truediv")
     __floordiv__ = _operator_factory("floordiv")
     __mod__ = _operator_factory("mod")
@@ -184,8 +179,6 @@ class ACAImage(np.ndarray):
     __iadd__ = _operator_factory("iadd", inplace=True)
     __isub__ = _operator_factory("isub", inplace=True)
     __imul__ = _operator_factory("imul", inplace=True)
-    if not six.PY3:
-        __idiv__ = _operator_factory("idiv", inplace=True)
     __itruediv__ = _operator_factory("itruediv", inplace=True)
     __ifloordiv__ = _operator_factory("ifloordiv", inplace=True)
     __imod__ = _operator_factory("imod", inplace=True)
@@ -305,9 +298,8 @@ class ACAImage(np.ndarray):
 
         return row, col, norm
 
-    @override__dir__
     def __dir__(self):
-        return list(self.meta)
+        return sorted(super().__dir__() + list(self.meta))
 
     @property
     def row0(self):

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -4,7 +4,6 @@ import copy
 import os
 import pickle
 
-import astropy.units as u
 import maude
 import numpy as np
 import pytest
@@ -281,8 +280,7 @@ def test_vcdu_vs_level0():
         "TEMPSEC",
         "BGDSTAT",
     ]
-    # u_DN = u.def_unit("DN")
-    # u.add_enabled_units(u.DN)
+
     for slot in range(8):
         l0_test_data = Table.read(
             os.path.join(

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -4,6 +4,7 @@ import copy
 import os
 import pickle
 
+import astropy.units as u
 import maude
 import numpy as np
 import pytest
@@ -280,11 +281,14 @@ def test_vcdu_vs_level0():
         "TEMPSEC",
         "BGDSTAT",
     ]
+    # u_DN = u.def_unit("DN")
+    # u.add_enabled_units(u.DN)
     for slot in range(8):
         l0_test_data = Table.read(
             os.path.join(
                 os.path.dirname(__file__), "data", f"test_level0_{slot}.fits.gz"
-            )
+            ),
+            unit_parse_strict="silent",
         )
         td = l0_test_data[
             (l0_test_data["TIME"] <= stop) * (l0_test_data["TIME"] >= start)

--- a/chandra_aca/tests/test_psf.py
+++ b/chandra_aca/tests/test_psf.py
@@ -57,8 +57,6 @@ def test_centroids():
                     assert np.isclose(r, rc, rtol=0, atol=atol)
                     assert np.isclose(c, cc, rtol=0, atol=atol)
 
-    return outr, outc
-
 
 def test_psf_at_index_location():
     """Test that requesting a PSF image at exactly an existing location in the


### PR DESCRIPTION
## Description

Fix deprecations etc for ska3-prime.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
`pytest chandra_aca` on Mac was successful with no reported warnings at the end.

Also, tested `ACAImage.__dir__()` by creating an `ACAImage` object and then using IPython <tab> completion to see the expected custom attributes.