### PR TITLE
Remove use of astropy override__dir__

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numba
 import numpy as np
 import six
-from astropy.utils.compat.misc import override__dir__
 from six.moves import zip
 
 __all__ = ["ACAImage", "centroid_fm", "AcaPsfLibrary", "EIGHT_LABELS"]
@@ -305,9 +304,8 @@ class ACAImage(np.ndarray):
 
         return row, col, norm
 
-    @override__dir__
     def __dir__(self):
-        return list(self.meta)
+        return sorted(set(super().__dir__()) | set(self.meta))
 
     @property
     def row0(self):


### PR DESCRIPTION
## Description

This PR removes the use of deprecated decorator `astropy.utils.compat.misc.override__dir__` and replaces it with the suggestion in the docstring of `override__dir__`.

which causes the following warning:
```
WARNING: AstropyDeprecationWarning: http://bugs.python.org/issue12166 is resolved. See docstring for alternatives. [chandra_aca.aca_image]
```

## Interface impacts
None

## Testing

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->

- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I checked that the deprecation warning is gone in 2023.1rc4:
```
python -c 'import chandra_aca.aca_image'
```

I also checked in the command line that `IMGCOL0` and `IMGROW0` are in `__dir__()`
