### PR TITLE
fix in planets.py: cleanup jplephem.spk.SPK at exit

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -40,7 +40,6 @@ def _operator_factory(operator, inplace=False):
     inplace_op = op if inplace else getattr(np.ndarray, "__i{}__".format(operator))
 
     def _operator(self, other):
-
         if isinstance(other, ACAImage) and (other._aca_coords or self._aca_coords):
             # If inplace then work on the original self, else use a copy
             out = self if inplace else self.copy()
@@ -58,7 +57,6 @@ def _operator_factory(operator, inplace=False):
                     other.col0 + sz_c1 - self.col0,
                 ]
             ):
-
                 dr = other.row0 - self.row0
                 dc = other.col0 - self.col0
 
@@ -130,7 +128,6 @@ class ACAImage(np.ndarray):
         return obj
 
     def __new__(cls, *args, **kwargs):
-
         meta = kwargs.pop("meta", {})
 
         # Set default row0 and col0 to 0 (if not already in meta), and
@@ -454,7 +451,6 @@ class ACAImage(np.ndarray):
             self._flicker_update_vectorized(dt)
 
     def _flicker_update_vectorized(self, dt):
-
         self.flicker_times[self.flicker_mask_vals] -= dt
 
         # When flicker_times < 0 that means a flicker occurs

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -74,7 +74,13 @@ def load_kernel():
             'run "python setup.py build" to install it locally'
         )
     kernel = SPK.open(kernel_path)
+    import atexit
+    atexit.register(_close_kernel)
     return kernel
+
+
+def _close_kernel():
+    KERNEL.val.close()
 
 
 KERNEL = LazyVal(load_kernel)

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -75,6 +75,7 @@ def load_kernel():
         )
     kernel = SPK.open(kernel_path)
     import atexit
+
     atexit.register(_close_kernel)
     return kernel
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -631,7 +631,6 @@ def test_dynbgd_decom():
                 raw_frames[key], combine=True, start=start, stop=stop
             )
             for slot in range(8):
-
                 assert np.all(
                     partial_packets[key][
                         "TIME", "VCDUCTR", "IMGTYPE", "BGDTYP", "PIXTLM"

--- a/chandra_aca/transform.py
+++ b/chandra_aca/transform.py
@@ -212,7 +212,6 @@ def yagzag_to_pixels(yang, zang, allow_bad=False, pix_zero_loc="edge"):
 
 
 def _poly_convert(y, z, coeffs, t_aca=None):
-
     # Convert to avoid overflow errors with the polys on int32
     y = np.asarray(y, dtype=np.float64)
     z = np.asarray(z, dtype=np.float64)


### PR DESCRIPTION
## Description

The current sparkles unit test on masters (ska3-prime) has the following warning at the end:
```
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name='/export/jgonzale/github-workflows/miniconda3/envs/ska3-masters-prime/lib/python3.10/site-packages/chandra_aca/data/de432s.bsp'>
```

This is caused by `chandra_aca.planets.load_kernel`, which opens a file that is never closed. This PR adds a cleanup function to fix that.

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I ran sparkles unit test using this branch and this silenced the warning.
