### PR TITLE
Prevent crash when IMGTYPE==3 when using blobs

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -521,12 +521,11 @@ def _combine_aca_packets(aca_packets):
     pixels = np.ma.masked_all((8, 8))
     pixels.data[:] = np.nan
     for f in aca_packets:
-        i0, i1 = _IMG_INDICES[f["IMGTYPE"]]
-        pixels[i0, i1] = f["pixels"]
         # IMGTYPE 3 is not a real image. It means the pixels are used to download engineering data
-        # We set the pixel values to the values in telemetry, but mask them.
-        if f["IMGTYPE"] == 3:
-            pixels.mask[i0, i1] = True
+        # if IMGTYPE == 3, do nothing. All pixels will be masked
+        if f["IMGTYPE"] != 3:
+            i0, i1 = _IMG_INDICES[f["IMGTYPE"]]
+            pixels[i0, i1] = f["pixels"]
 
     for f in aca_packets:
         res.update(f)

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -324,7 +324,7 @@ _a2p = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O
 # - Type 0 is 4x4,
 # - Types 1 (first batch of 6x6) and 4 (first batch of 8x8) use the same pixel IDs as 4x4.
 # - Type 3 is not a real image type. It occurs when the image telemetry is used to download
-#   engineering data. In this case, the image is treated as 4x4, but the values will be giberish.
+#   memory dump data. In this case, the image is treated as 4x4, but the values might be giberish.
 # - Types 2 (second batch of 6x6) and 5 (second batch of 8x8) use the same pixel IDs.
 _IMG_INDICES = [
     np.array([PIXEL_MAP_INV["4x4"][f"{k}1"] for k in _a2p]).T,
@@ -521,7 +521,7 @@ def _combine_aca_packets(aca_packets):
     pixels = np.ma.masked_all((8, 8))
     pixels.data[:] = np.nan
     for f in aca_packets:
-        # IMGTYPE 3 is not a real image. It means the pixels are used to download engineering data
+        # IMGTYPE 3 is not a real image. It means the pixels are used to download memory dump data
         # if IMGTYPE == 3, do nothing. All pixels will be masked
         if f["IMGTYPE"] != 3:
             i0, i1 = _IMG_INDICES[f["IMGTYPE"]]

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -760,8 +760,8 @@ def test_imgtype_dnld(source):
     """
     from cxotime import CxoTime
 
-    start = CxoTime("2023:047:02:58:13.213")
-    stop = CxoTime("2023:047:02:58:14.239")
+    start = CxoTime("2023:047:02:57")
+    stop = CxoTime("2023:047:02:58")
     if source == "blobs":
         maude_result = maude.get_blobs(start, stop, channel="FLIGHT")
         args = {"blobs": maude_result}
@@ -775,4 +775,5 @@ def test_imgtype_dnld(source):
 
     all_masked = np.array([np.all(row["IMG"].mask) for row in img])
     img_dnld = img["IMGTYPE"] == 3
+    assert img_dnld.shape[0] > 0
     assert np.all(all_masked == img_dnld)

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -753,27 +753,24 @@ def test_get_aca_packets_blobs():
     assert blobs == ref_blobs
 
 
-def test_imgtype_dnld():
+@pytest.mark.parametrize("source", ["blobs", "frames"])
+def test_imgtype_dnld(source):
     """
-    Tests for the case when IMGTYPE is DNLD
+    Tests for the case when IMGTYPE is DNLD (from blobs)
     """
+    from cxotime import CxoTime
 
-    start = "2023:047:02:58:13.213"
-    stop = "2023:047:02:58:14.239"
-    maude_result = maude.get_frames(start, stop, channel="FLIGHT")
-    raw_aca_packets = maude_decom.get_raw_aca_packets(
-        start, stop, maude_result=maude_result
-    )
-    # decom_packets = [maude_decom.unpack_aca_telemetry(a) for a in raw_aca_packets["packets"]]
-    # assert 3 not in [p['IMGTYPE'] for packet in decom_packets for p in packet]
+    start = CxoTime("2023:047:02:58:13.213")
+    stop = CxoTime("2023:047:02:58:14.239")
+    if source == "blobs":
+        maude_result = maude.get_blobs(start, stop, channel="FLIGHT")
+        args = {"blobs": maude_result}
+    else:
+        maude_result = maude.get_frames(start, stop, channel="FLIGHT")
+        args = {"frames": maude_result}
 
-    img = maude_decom._get_aca_packets(
-        raw_aca_packets,
-        start,
-        stop,
-        combine=False,
-        adjust_time=False,
-        calibrate=False,
+    img = maude_decom.get_aca_packets(
+        start, stop, combine=False, adjust_time=False, calibrate=False, **args
     )
 
     all_masked = np.array([np.all(row["IMG"].mask) for row in img])

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -756,7 +756,7 @@ def test_get_aca_packets_blobs():
 @pytest.mark.parametrize("source", ["blobs", "frames"])
 def test_imgtype_dnld(source):
     """
-    Tests for the case when IMGTYPE is DNLD (from blobs)
+    Tests for the case when IMGTYPE is DNLD.
     """
     from cxotime import CxoTime
 


### PR DESCRIPTION
## Description

Image telemetry can be used to download engineering data. In this case `IMGTYPE==3`. MAUDE is smart enough to recognize that the corresponding pixel MSIDs are not present whenever `IMGTYPE==3`, and the MSIDs are not present in the blob. This in turn causes an empty list to be assigned to a pixel array, and an exception being raised with the following error:
```
ValueError: shape mismatch: value array of shape (0,) could not be broadcast to indexing result of shape (16,)
```

When data comes from frames, the pixels have non-zero values corresponding with the data in telemetry, but they are all masked. If the data comes from blobs, the pixels values are zero and are masked.

## Interface impacts
None

## Testing

I added a unit test for this case. There was already a test from frames, I just added it for blobs.

This issue showed up using aca_view during anomaly. The changes in this PR were later used during patch uplink.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Mac 

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functional testing using aca_view
