### PR TITLE
Use chandra_models_cache for caching not lru_cache

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -18,8 +18,6 @@ The grid-floor-2020-02 model definition and fit values based on:
 - SSAWG review: 2020-01-29
 """
 
-import functools
-import os
 import re
 import warnings
 from pathlib import Path
@@ -420,7 +418,7 @@ def get_grid_axis_values(hdr, axis):
     return vals
 
 
-@functools.lru_cache
+@chandra_models.chandra_models_cache
 def get_grid_func_model(
     model: Optional[str] = None,
     version: Optional[str] = None,
@@ -443,6 +441,7 @@ def get_grid_func_model(
         "t_ccd_hi": upper bound of t_ccd axis
         "halfw_lo": lower bound of halfw axis
         "halfw_hi": upper bound of halfw axis
+        "info": dict of provenance info for model file
 
     :param model: Model name (optional)
     :param version: Version / tag / branch of ``chandra_models`` repository (optional)
@@ -553,11 +552,7 @@ def grid_model_acq_prob(
     """
     # Get the grid model function and model parameters from a FITS file. This function
     # call is cached.
-    gfm = get_grid_func_model(
-        model,
-        version=os.environ.get("CHANDRA_MODELS_DEFAULT_VERSION"),
-        repo_path=os.environ.get("CHANDRA_MODELS_REPO_PATH"),
-    )
+    gfm = get_grid_func_model(model)
 
     func_no_1p5 = gfm["func_no_1p5"]
     func_1p5 = gfm["func_1p5"]

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -14,6 +14,7 @@ from chandra_aca.star_probs import (
     binom_ppf,
     conf,
     get_default_acq_prob_model_info,
+    get_grid_func_model,
     grid_model_acq_prob,
     guide_count,
     mag_for_p_acq,
@@ -662,3 +663,16 @@ def test_md5_2020_02():
 def test_binom_ppf():
     vals = binom_ppf(4, 5, [0.17, 0.84])
     assert np.allclose(vals, [0.55463945, 0.87748177])
+
+
+def test_grid_model_3_48(monkeypatch):
+    """Test that we can adjust the chandra_models repo version and get the
+    expected file. For version 3.48 the most recent file is grid-floor-2020-02.fits.gz.
+    The grid-local-quadratic-2023-05.fits.gz file was added in version 3.49.
+    """
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    gfm = get_grid_func_model(model="grid-*")
+    info = gfm["info"]
+    assert info["version"] == "3.48"
+    assert info["data_file_path"].endswith("grid-floor-2020-02.fits.gz")
+    assert info["commit"] == "68a58099a9b51bef52ef14fbd0f1971f950e6ba3"


### PR DESCRIPTION
## Description

This updates the function to get the acq probability model (from chandra_models) to cache using `chandra_models_cache` from https://github.com/sot/ska_helpers/pull/36.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
In a dev Ska environment with https://github.com/sot/ska_helpers/pull/36 installed.
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new test)

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
