### PR TITLE
Add function to get default acq prob model info

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -329,6 +329,39 @@ def acq_success_prob(
     return probs[0] if is_scalar else probs
 
 
+def get_default_acq_prob_model_info():
+    """Get info about the default acquisition probability model.
+
+    Example::
+
+        >>> from chandra_aca import star_probs
+        >>> star_probs.get_default_acq_prob_model_info()
+        {'default_model': 'grid-*',
+         'call_args': {'file_path': 'chandra_models/aca_acq_prob',
+          'version': None,
+          'repo_path': 'None',
+          'require_latest_version': False,
+          'timeout': 5,
+          'read_func': '<function _read_grid_func_model at 0x11a443b50>',
+          'read_func_kwargs': {'model_name': None}},
+         'version': '3.48',
+         'commit': '68a58099a9b51bef52ef14fbd0f1971f950e6ba3',
+         'data_file_path': '/Users/aldcroft/ska/data/chandra_models/chandra_models/aca_acq_prob/grid-floor-2020-02.fits.gz',
+         'repo_path': '/Users/aldcroft/ska/data/chandra_models',
+         'md5': '3a47774392beeca2921b705e137338f4',
+         'CHANDRA_MODELS_REPO_DIR': None,
+         'CHANDRA_MODELS_DEFAULT_VERSION': None,
+         'THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW': None}
+
+    :returns: dict of model info
+    """  # noqa: E501
+    info = {"default_model": conf.default_model}
+    if info["default_model"].startswith("grid-"):
+        gfm = get_grid_func_model()
+        info.update(gfm["info"])
+    return info
+
+
 def clip_and_warn(name, val, val_lo, val_hi, model):
     """
     Clip ``val`` to be in the range ``val_lo`` to ``val_hi`` and issue a

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -329,7 +329,7 @@ def acq_success_prob(
     return probs[0] if is_scalar else probs
 
 
-def get_default_acq_prob_model_info():
+def get_default_acq_prob_model_info(verbose=True):
     """Get info about the default acquisition probability model.
 
     Example::
@@ -353,12 +353,22 @@ def get_default_acq_prob_model_info():
          'CHANDRA_MODELS_DEFAULT_VERSION': None,
          'THERMAL_MODELS_DIR_FOR_MATLAB_TOOLS_SW': None}
 
+    :param verbose: bool
+        If False then return trimmed version with no call_args and None values removed.
     :returns: dict of model info
     """  # noqa: E501
     info = {"default_model": conf.default_model}
     if info["default_model"].startswith("grid-"):
         gfm = get_grid_func_model()
         info.update(gfm["info"])
+
+    # Allow a trimmed down version (e.g. for proseco to avoid bloating the pickle)
+    if not verbose:
+        del info["call_args"]
+        for key, val in list(info.items()):
+            if val is None:
+                del info[key]
+
     return info
 
 

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -390,10 +390,8 @@ def clip_and_warn(name, val, val_lo, val_hi, model):
     val = np.asarray(val)
     if np.any((val > val_hi) | (val < val_lo)):
         warnings.warn(
-            "\nModel {} computed between {} <= {} <= {}, "
-            "clipping input {}(s) outside that range.".format(
-                model, name, val_lo, val_hi, name
-            )
+            f"\nModel {model} computed between {val_lo} <= {name} <= {val_hi}, "
+            f"clipping input {name}(s) outside that range."
         )
         val = np.clip(val, val_lo, val_hi)
 
@@ -570,10 +568,12 @@ def grid_model_acq_prob(
     halfw_lo = gfm["halfw_lo"]
     halfw_hi = gfm["halfw_hi"]
 
+    model_filename = Path(gfm["info"]["data_file_path"]).name
+
     # Make sure inputs are within range of gridded model
-    mag = clip_and_warn("mag", mag, mag_lo, mag_hi, model)
-    t_ccd = clip_and_warn("t_ccd", t_ccd, t_ccd_lo, t_ccd_hi, model)
-    halfwidth = clip_and_warn("halfw", halfwidth, halfw_lo, halfw_hi, model)
+    mag = clip_and_warn("mag", mag, mag_lo, mag_hi, model_filename)
+    t_ccd = clip_and_warn("t_ccd", t_ccd, t_ccd_lo, t_ccd_hi, model_filename)
+    halfwidth = clip_and_warn("halfw", halfwidth, halfw_lo, halfw_hi, model_filename)
 
     # Broadcast all inputs to a common shape.  If they are all scalars
     # then shape=().  The returns values are flattened, so the final output

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -6,12 +6,14 @@ import os
 import numpy as np
 import pytest
 from astropy.table import Table
+from ska_helpers import chandra_models
 from ska_helpers.paths import aca_acq_prob_models_path
 
 from chandra_aca.star_probs import (
     acq_success_prob,
     binom_ppf,
     conf,
+    get_default_acq_prob_model_info,
     grid_model_acq_prob,
     guide_count,
     mag_for_p_acq,
@@ -579,6 +581,34 @@ def test_default_acq_prob_model():
 
     # Should be identical to the bit because the same code is called.
     assert np.all(probs1 == probs2)
+
+
+def test_get_default_acq_prob_model_info(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    info = get_default_acq_prob_model_info()
+
+    del info["data_file_path"]
+    del info["repo_path"]
+    del info["call_args"]["read_func"]
+    del info["call_args"]["read_func_kwargs"]
+
+    exp = {
+        "default_model": "grid-*",
+        "call_args": {
+            "file_path": "chandra_models/aca_acq_prob",
+            "version": None,
+            "repo_path": "None",
+            "require_latest_version": False,
+            "timeout": 5,
+        },
+        "version": "3.48",
+        "commit": "68a58099a9b51bef52ef14fbd0f1971f950e6ba3",
+        "md5": "3a47774392beeca2921b705e137338f4",
+    }
+    for name in chandra_models.ENV_VAR_NAMES:
+        exp[name] = os.environ.get(name)
+
+    assert info == exp
 
 
 def test_md5_2020_02():

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -583,9 +583,10 @@ def test_default_acq_prob_model():
     assert np.all(probs1 == probs2)
 
 
-def test_get_default_acq_prob_model_info(monkeypatch):
+def test_get_default_acq_prob_model_info_grid(monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
-    info = get_default_acq_prob_model_info()
+    with conf.set_temp("default_model", "grid-*"):
+        info = get_default_acq_prob_model_info()
 
     del info["data_file_path"]
     del info["repo_path"]
@@ -609,6 +610,13 @@ def test_get_default_acq_prob_model_info(monkeypatch):
         exp[name] = os.environ.get(name)
 
     assert info == exp
+
+
+def test_get_default_acq_prob_model_info_sota():
+    with conf.set_temp("default_model", "sota"):
+        info = get_default_acq_prob_model_info()
+
+    assert info == {"default_model": "sota"}
 
 
 def test_md5_2020_02():

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -612,6 +612,27 @@ def test_get_default_acq_prob_model_info_grid(monkeypatch):
     assert info == exp
 
 
+def test_get_default_acq_prob_model_info_grid_no_verbose(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    with conf.set_temp("default_model", "grid-*"):
+        info = get_default_acq_prob_model_info(verbose=False)
+
+    del info["data_file_path"]
+    del info["repo_path"]
+
+    exp = {
+        "default_model": "grid-*",
+        "version": "3.48",
+        "commit": "68a58099a9b51bef52ef14fbd0f1971f950e6ba3",
+        "md5": "3a47774392beeca2921b705e137338f4",
+    }
+    for name in chandra_models.ENV_VAR_NAMES:
+        if val := os.environ.get(name):
+            exp[name] = val
+
+    assert info == exp
+
+
 def test_get_default_acq_prob_model_info_sota():
     with conf.set_temp("default_model", "sota"):
         info = get_default_acq_prob_model_info()

--- a/chandra_aca/tests/test_star_probs.py
+++ b/chandra_aca/tests/test_star_probs.py
@@ -612,6 +612,16 @@ def test_get_default_acq_prob_model_info_grid(monkeypatch):
     assert info == exp
 
 
+def test_clip_warning(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+    with pytest.warns(
+        UserWarning,
+        match=r"Model grid-floor-2020-02.fits.gz computed between 5.0 <= mag <= 12.0",
+    ):
+        with conf.set_temp("default_model", "grid-floor-2020-02"):
+            acq_success_prob(mag=20)
+
+
 def test_get_default_acq_prob_model_info_grid_no_verbose(monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
     with conf.set_temp("default_model", "grid-*"):


### PR DESCRIPTION
## Description

This adds a new function to get provenance information about the default acquisition probability model (subject to environment variables). This is intended to be used in proseco to add this info to the star catalogs pickle file.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds new function `get_default_acq_prob_model_info`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
In a dev Ska environment with https://github.com/sot/ska_helpers/pull/36 installed.
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new test)

Independent check of unit tests by Jean
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing. (but there is a new unit test to cover the new functionality)
