### PR TITLE
Improve caching performance by adjusting default call pattern

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -551,8 +551,10 @@ def grid_model_acq_prob(
 
     """
     # Get the grid model function and model parameters from a FITS file. This function
-    # call is cached.
-    gfm = get_grid_func_model(model)
+    # call is cached. If ``model is None``` then don't pass any args so that caching
+    # matches the other in this module of ``get_grid_func_model()``.
+    args = (model,) if model is not None else ()
+    gfm = get_grid_func_model(*args)
 
     func_no_1p5 = gfm["func_no_1p5"]
     func_1p5 = gfm["func_1p5"]

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -555,8 +555,7 @@ def grid_model_acq_prob(
 
     """
     # Get the grid model function and model parameters from a FITS file. This function
-    # call is cached. If ``model is None``` then don't pass any args so that caching
-    # matches the other in this module of ``get_grid_func_model()``.
+    # call is cached.
     gfm = get_grid_func_model(model)
 
     func_no_1p5 = gfm["func_no_1p5"]

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -418,7 +418,6 @@ def get_grid_axis_values(hdr, axis):
     return vals
 
 
-@chandra_models.chandra_models_cache
 def get_grid_func_model(
     model: Optional[str] = None,
     version: Optional[str] = None,
@@ -448,6 +447,11 @@ def get_grid_func_model(
     :param repo_path: Path to ``chandra_models`` repository (optional)
     :returns: dict of model data
     """
+    return _get_grid_func_model(model, version, repo_path)
+
+
+@chandra_models.chandra_models_cache
+def _get_grid_func_model(model, version, repo_path):
     data, info = chandra_models.get_data(
         file_path="chandra_models/aca_acq_prob",
         read_func=_read_grid_func_model,
@@ -553,8 +557,7 @@ def grid_model_acq_prob(
     # Get the grid model function and model parameters from a FITS file. This function
     # call is cached. If ``model is None``` then don't pass any args so that caching
     # matches the other in this module of ``get_grid_func_model()``.
-    args = (model,) if model is not None else ()
-    gfm = get_grid_func_model(*args)
+    gfm = get_grid_func_model(model)
 
     func_no_1p5 = gfm["func_no_1p5"]
     func_1p5 = gfm["func_1p5"]

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -34,7 +34,7 @@ def _compare_common_columns(t1, t2, keys=None, exclude=()):
     errors = []
     for name in keys:
         col_1, col_2 = t1[name], t2[name]
-        ok = type(col_1) == type(col_2)
+        ok = type(col_1) is type(col_2)
         if type(col_1) is table.MaskedColumn and type(col_1) is table.MaskedColumn:
             ok &= np.all(col_1.mask == col_2.mask)
         if np.issubdtype(col_1.dtype, np.inexact) or np.issubdtype(


### PR DESCRIPTION
## Description

In default usage @jeanconn noted that `get_grid_func_model` was being called once with `get_grid_func_model()` and once with `get_grid_func_model(None)`, thus requiring two reads of the model file. This fixes that.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
In [1]: from chandra_aca import star_probs

In [2]: %time model = star_probs.get_grid_func_model()
CPU times: user 23.5 ms, sys: 24.6 ms, total: 48.2 ms
Wall time: 82.8 ms

In [3]: %time model = star_probs.get_grid_func_model(None)
CPU times: user 27 µs, sys: 5 µs, total: 32 µs
Wall time: 34.8 µs

In [4]: %time model = star_probs.get_grid_func_model("grid-*")
CPU times: user 20.4 ms, sys: 18.4 ms, total: 38.8 ms
Wall time: 68.2 ms
```
