### PR TITLE
Improve caching performance by adjusting default call pattern (take 2)

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -447,6 +447,8 @@ def get_grid_func_model(
     :param repo_path: Path to ``chandra_models`` repository (optional)
     :returns: dict of model data
     """
+    if model is None:
+        model = conf.default_model
     return _get_grid_func_model(model, version, repo_path)
 
 


### PR DESCRIPTION
## Description

This improved on #153 by setting `model=conf.default_model` when calling `_get_grid_func_model` whenever `model is None`

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [x] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

Same as in #153, but fixing the last call:
```
In [1]: from chandra_aca import star_probs

In [2]: %time model = star_probs.get_grid_func_model()
CPU times: user 17.9 ms, sys: 2.05 ms, total: 19.9 ms
Wall time: 280 ms

In [3]: %time model = star_probs.get_grid_func_model(None)
CPU times: user 59 µs, sys: 0 ns, total: 59 µs
Wall time: 66.3 µs

In [4]: %time model = star_probs.get_grid_func_model("grid-*")
CPU times: user 21 µs, sys: 3 µs, total: 24 µs
Wall time: 29.6 µs
```
