### PR TITLE
Add fid offset support to drift

### DIFF
--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -17,6 +17,7 @@ import numpy as np
 from astropy.table import Table
 from astropy.utils.data import download_file
 from Chandra.Time import DateTime
+from cxotime import CxoTimeLike
 from ska_helpers import chandra_models
 from ska_helpers.utils import LazyDict
 
@@ -165,15 +166,30 @@ class AcaDriftModel(object):
         return out[0] if is_scalar else out
 
 
-def get_fid_offset(time, t_ccd):
+def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
     """
-    Compute the fid light offset values for a given ``time`` and ``t_ccd``.
-    
+    Compute the fid light offset values for a given time and temperature.
+
+    Parameters
+    ----------
+    time : CxoTimeLike format
+        Time for offset calculation.
+    t_ccd : float
+        ACA CCD temperature in degrees Celsius.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the y-angle and z-angle offsets (in arcseconds) to apply
+        additively to the nominal (FEB07) fid positions.
+
+    Notes
+    -----
     The apparent fid light positions change in accordance with the ACA alignment drift as a function
     of time and temperature. This is captured in the ACA aimpoint drift model. This function uses that
-    model to provide the offsets in y-angle and z-angle (arcsec) to apply additively to the nominal 
+    model to provide the offsets in y-angle and z-angle (arcsec) to apply additively to the nominal
     fid positions.
-    
+
     The y_offset and z_offset values in this function were calibrated using the
     2022-11 aimpoint drift model and the FEB07 fid characteristics.
     See https://github.com/sot/fid_drift_mon/blob/master/fid_offset_coeff.ipynb

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -207,8 +207,8 @@ def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
 
     # Apply internal offset that places the fid lights at ~zero position
     # offset during the 2022:094 to 2023:044.
-    y_offset = 20.3
-    z_offset = 20.3
+    y_offset = 19.6
+    z_offset = 20.1
     return dy_pred + y_offset, dz_pred + z_offset
 
 

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -165,6 +165,28 @@ class AcaDriftModel(object):
         return out[0] if is_scalar else out
 
 
+def get_fid_offset(time, t_ccd):
+    """
+    Compute the fid light offset values for the provided inputs.
+    """
+
+    # Define model instances using calibrated parameters
+    drift_y = AcaDriftModel(**DRIFT_PARS["dy"])
+    drift_z = AcaDriftModel(**DRIFT_PARS["dz"])
+
+    # Compute the predicted asol DY/DZ based on time and ACA CCD temperature
+    # via the predictive model calibrated in the fit_aimpoint_drift notebook
+    # in this repo.  And flip the signs.
+    dy_pred = -1.0 * drift_y.calc(time, t_ccd)
+    dz_pred = -1.0 * drift_z.calc(time, t_ccd)
+
+    # Apply internal offset that places the fid lights at ~zero position
+    # offset during the 2022:094 to 2023:044.
+    y_offset = 20.3
+    z_offset = 20.3
+    return dy_pred + y_offset, dz_pred + z_offset
+
+
 def get_aca_offsets(detector, chip_id, chipx, chipy, time, t_ccd):
     """
     Compute the dynamical ACA offset values for the provided inputs.

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -168,6 +168,9 @@ class AcaDriftModel(object):
 def get_fid_offset(time, t_ccd):
     """
     Compute the fid light offset values for the provided inputs.
+    The y_offset and z_offset values in this function were calibrated against the
+    2022-11 aimpoint drift model and the FEB07 fid characteristics.
+    See https://github.com/sot/fid_drift_mon/blob/master/fid_offset_coeff.ipynb
     """
 
     # Define model instances using calibrated parameters

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -167,8 +167,14 @@ class AcaDriftModel(object):
 
 def get_fid_offset(time, t_ccd):
     """
-    Compute the fid light offset values for the provided inputs.
-    The y_offset and z_offset values in this function were calibrated against the
+    Compute the fid light offset values for a given ``time`` and ``t_ccd``.
+    
+    The apparent fid light positions change in accordance with the ACA alignment drift as a function
+    of time and temperature. This is captured in the ACA aimpoint drift model. This function uses that
+    model to provide the offsets in y-angle and z-angle (arcsec) to apply additively to the nominal 
+    fid positions.
+    
+    The y_offset and z_offset values in this function were calibrated using the
     2022-11 aimpoint drift model and the FEB07 fid characteristics.
     See https://github.com/sot/fid_drift_mon/blob/master/fid_offset_coeff.ipynb
     """

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -185,10 +185,10 @@ def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
 
     Notes
     -----
-    The apparent fid light positions change in accordance with the ACA alignment drift as a function
-    of time and temperature. This is captured in the ACA aimpoint drift model. This function uses that
-    model to provide the offsets in y-angle and z-angle (arcsec) to apply additively to the nominal
-    fid positions.
+    The apparent fid light positions change in accordance with the ACA alignment drift as a
+    function of time and temperature. This is captured in the ACA aimpoint drift model. This
+    function uses that model to provide the offsets in y-angle and z-angle (arcsec) to apply
+    additively to the nominal fid positions.
 
     The y_offset and z_offset values in this function were calibrated using the
     2022-11 aimpoint drift model and the FEB07 fid characteristics.

--- a/chandra_aca/tests/test_drift.py
+++ b/chandra_aca/tests/test_drift.py
@@ -67,3 +67,31 @@ def test_get_aca_offsets(kwargs, monkeypatch):
     # 3.9 arcsec/C. Also up to 0.005 arcsec error in the stored aca_offset_y/z values.
     assert abs(dy) < 0.03
     assert abs(dz) < 0.02
+
+
+def test_get_fid_offset():
+    """
+    Test that the get_fid_offset function returns expected values for a few inputs.
+    """
+
+    # Show that the offsets are reasonable for a few inputs in the different epochs
+    # of the drift model. Dates picked to be before and after jumps
+    t1 = "2018:284"
+    t2 = "2018:286"
+    t3 = "2022:293"
+    t4 = "2022:295"
+
+    t_ccd = -10
+
+    expected_dy_1, expected_dz_1 = drift.get_fid_offset(t1, t_ccd)
+    expected_dy_2, expected_dz_2 = drift.get_fid_offset(t2, t_ccd)
+    expected_dy_3, expected_dz_3 = drift.get_fid_offset(t3, t_ccd)
+    expected_dy_4, expected_dz_4 = drift.get_fid_offset(t4, t_ccd)
+
+    assert np.isclose(expected_dy_1, -6.79, atol=0.01)
+    assert np.isclose(expected_dy_2 - expected_dy_1, 12.5, atol=0.1)
+    assert np.isclose(expected_dy_4 - expected_dy_3, 7.97, atol=0.1)
+
+    assert np.isclose(expected_dz_1, -5.10, atol=0.01)
+    assert np.isclose(expected_dz_2 - expected_dz_1, 6.05, atol=0.1)
+    assert np.isclose(expected_dz_4 - expected_dz_3, 1.51, atol=0.1)

--- a/chandra_aca/tests/test_drift.py
+++ b/chandra_aca/tests/test_drift.py
@@ -88,10 +88,10 @@ def test_get_fid_offset():
     expected_dy_3, expected_dz_3 = drift.get_fid_offset(t3, t_ccd)
     expected_dy_4, expected_dz_4 = drift.get_fid_offset(t4, t_ccd)
 
-    assert np.isclose(expected_dy_1, -6.79, atol=0.01)
+    assert np.isclose(expected_dy_1, -7.50, atol=0.01)
     assert np.isclose(expected_dy_2 - expected_dy_1, 12.5, atol=0.1)
     assert np.isclose(expected_dy_4 - expected_dy_3, 7.97, atol=0.1)
 
-    assert np.isclose(expected_dz_1, -5.10, atol=0.01)
+    assert np.isclose(expected_dz_1, -5.30, atol=0.01)
     assert np.isclose(expected_dz_2 - expected_dz_1, 6.05, atol=0.1)
     assert np.isclose(expected_dz_4 - expected_dz_3, 1.51, atol=0.1)


### PR DESCRIPTION
## Description

Add a function, get_fid_offset, to determine the expected y and z offsets of the fid lights from their positions, relative to the fid positions expected from the FEB07 fid characteristics (used in proseco and starcheck) and the current aimpoint drift model (which was last updated after the 2022:094 safe mode).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

For functional testing, there is a new unit test and this notebook shows the use of the new offsets reduces the fid residuals on historical data.

https://cxc.cfa.harvard.edu/mta/ASPECT/ipynb/chandra_aca_fid_offset/check_fid_offset.html
