### PR TITLE
Support fid drift times before 2012:001

### DIFF
--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -198,12 +198,7 @@ def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
     """
 
     # Clip the time to the minimum time in the drift model
-    # Handle scalar and array cases
-    if np.isscalar(time):
-        time = np.max([CxoTime(time).secs, CxoTime("2012:001:12:00:00").secs])
-    else:
-        # Clip the time array to the minimum time in the model
-        time = CxoTime(time).secs.clip(CxoTime("2012:001:12:00:00").secs, None)
+    time = CxoTime(time).secs.clip(CxoTime("2012:001:12:00:00.000").secs, None)
 
     # Define model instances using calibrated parameters
     drift_y = AcaDriftModel(**DRIFT_PARS["dy"])

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -17,7 +17,7 @@ import numpy as np
 from astropy.table import Table
 from astropy.utils.data import download_file
 from Chandra.Time import DateTime
-from cxotime import CxoTimeLike
+from cxotime import CxoTime, CxoTimeLike
 from ska_helpers import chandra_models
 from ska_helpers.utils import LazyDict
 
@@ -170,6 +170,8 @@ def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
     """
     Compute the fid light offset values for a given time and temperature.
 
+    The ``time`` and ``t_ccd`` inputs can be either scalars or arrays.
+
     Parameters
     ----------
     time : CxoTimeLike format
@@ -194,6 +196,14 @@ def get_fid_offset(time: CxoTimeLike, t_ccd: float) -> tuple:
     2022-11 aimpoint drift model and the FEB07 fid characteristics.
     See https://github.com/sot/fid_drift_mon/blob/master/fid_offset_coeff.ipynb
     """
+
+    # Clip the time to the minimum time in the drift model
+    # Handle scalar and array cases
+    if np.isscalar(time):
+        time = np.max([CxoTime(time).secs, CxoTime("2012:001:12:00:00").secs])
+    else:
+        # Clip the time array to the minimum time in the model
+        time = CxoTime(time).secs.clip(CxoTime("2012:001:12:00:00").secs, None)
 
     # Define model instances using calibrated parameters
     drift_y = AcaDriftModel(**DRIFT_PARS["dy"])


### PR DESCRIPTION
## Description

Support fid drift times before 2012:001.  This is handled by just clipping the times to the range of the aimpoint drift model.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This may not be needed even for old regression loads, but without a change, the fid offset code would do this:
```
In [2]: get_fid_offset('2010:001', -14)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 get_fid_offset('2010:001', -14)

File ~/git/chandra_aca/chandra_aca/drift.py:205, in get_fid_offset(time, t_ccd)
    200 drift_z = AcaDriftModel(**DRIFT_PARS["dz"])
    202 # Compute the predicted asol DY/DZ based on time and ACA CCD temperature
    203 # via the predictive model calibrated in the fit_aimpoint_drift notebook
    204 # in this repo.  And flip the signs.
--> 205 dy_pred = -1.0 * drift_y.calc(time, t_ccd)
    206 dz_pred = -1.0 * drift_z.calc(time, t_ccd)
    208 # Apply internal offset that places the fid lights at ~zero position
    209 # offset during the 2022:094 to 2023:044.

File ~/git/chandra_aca/chandra_aca/drift.py:153, in AcaDriftModel.calc(self, times, t_ccd)
    150     raise ValueError("times arg must be monotonically increasing")
    152 if times[0] < DateTime("2012:001:12:00:00").secs:
--> 153     raise ValueError("model is not applicable before 2012")
    155 # Years from model `year0`
    156 dyears = DateTime(times, format="secs").frac_year - self.year0

ValueError: model is not applicable before 2012
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests added and simple functional test is fine.

```
In [1]: from chandra_aca.drift import get_fid_offset
In [2]: get_fid_offset('2010:001', -14)
Out[2]: (-12.334006738845702, -3.3898347868921164)
In [3]: get_fid_offset('2012:001', -14)
Out[3]: (-12.334006738845702, -3.3898347868921164)
```
