### PR TITLE
Add tolerance args to clip_and_warn

### DIFF
--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -389,9 +389,9 @@ def get_default_acq_prob_model_info(verbose=True):
     return info
 
 
-def clip_and_warn(name, val, val_lo, val_hi, model):
+def clip_and_warn(name, val, val_lo, val_hi, model, tol_lo=0.0, tol_hi=0.0):
     """
-    Clip ``val`` to be in the range ``val_lo`` to ``val_hi`` and issue a
+    Clip ``val`` to be in the range ``val_lo`` to ``val_hi + tol_hi`` and issue a
     warning if clipping occurs.  The ``name`` and ``model`` are just used in
     the warning.
 
@@ -407,17 +407,26 @@ def clip_and_warn(name, val, val_lo, val_hi, model):
         Maximum
     model
         Model name
+    tol_lo
+        Tolerance below ``val_lo`` for issuing a warning (default=0.0)
+    tol_hi
+        Tolerance above ``val_hi`` for issuing a warning (default=0.0)
 
     Returns
     -------
     Clipped value
     """
     val = np.asarray(val)
-    if np.any((val > val_hi) | (val < val_lo)):
+
+    # Provide a tolerance for emitting a warning clipping
+    if np.any((val > val_hi + tol_hi) | (val < val_lo - tol_lo)):
         warnings.warn(
             f"\nModel {model} computed between {val_lo} <= {name} <= {val_hi}, "
             f"clipping input {name}(s) outside that range."
         )
+
+    # Now clip to the actual limits
+    if np.any((val > val_hi) | (val < val_lo)):
         val = np.clip(val, val_lo, val_hi)
 
     return val
@@ -621,7 +630,8 @@ def grid_model_acq_prob(
     model_filename = Path(gfm["info"]["data_file_path"]).name
 
     # Make sure inputs are within range of gridded model
-    mag = clip_and_warn("mag", mag, mag_lo, mag_hi, model_filename)
+    # TODO: run additional test cases on ASVT, make a new model, remove tol_hi for mag.
+    mag = clip_and_warn("mag", mag, mag_lo, mag_hi, model_filename, tol_hi=0.25)
     t_ccd = clip_and_warn("t_ccd", t_ccd, t_ccd_lo, t_ccd_hi, model_filename)
     halfwidth = clip_and_warn("halfw", halfwidth, halfw_lo, halfw_hi, model_filename)
 

--- a/chandra_aca/star_probs.py
+++ b/chandra_aca/star_probs.py
@@ -391,9 +391,9 @@ def get_default_acq_prob_model_info(verbose=True):
 
 def clip_and_warn(name, val, val_lo, val_hi, model, tol_lo=0.0, tol_hi=0.0):
     """
-    Clip ``val`` to be in the range ``val_lo`` to ``val_hi + tol_hi`` and issue a
-    warning if clipping occurs.  The ``name`` and ``model`` are just used in
-    the warning.
+    Clip ``val`` to be in the range ``val_lo`` to ``val_hi`` and issue a
+    warning if clipping occurs, subject to ``tol_lo`` and ``tol_hi`` expansions.
+    The ``name`` and ``model`` are just used in the warning.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

The current acq probability model only extends to mag=10.75 while proseco will choose stars up to 11.0. This creates many warnings which we routinely ignore.

This PR just accepts that we are currently ignoring those warnings and makes them actually go away. Making a new model that samples up to 11.0 is a fairly substantial undertaking and the time scale for doing it is uncertain. When we do that we can back out this change.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Removes warnings.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  chandra_aca git:(allow-grid-model-extrapolation) git rev-parse HEAD
7d6134e5486f3a54ffff8057579ad94a507d4652
(ska3) ➜  chandra_aca git:(allow-grid-model-extrapolation) pytest chandra_aca  
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 197 items                                                                                                         

chandra_aca/tests/test_aca_image.py ..............                                                                    [  7%]
chandra_aca/tests/test_all.py ........................                                                                [ 19%]
chandra_aca/tests/test_attitude.py .............................................................                      [ 50%]
chandra_aca/tests/test_dark_model.py ....                                                                             [ 52%]
chandra_aca/tests/test_drift.py ..........................                                                            [ 65%]
chandra_aca/tests/test_maude_decom.py ...............                                                                 [ 73%]
chandra_aca/tests/test_planets.py .............                                                                       [ 79%]
chandra_aca/tests/test_psf.py ...                                                                                     [ 81%]
chandra_aca/tests/test_residuals.py ss...                                                                             [ 83%]
chandra_aca/tests/test_star_probs.py ................................                                                 [100%]

============================================== 195 passed, 2 skipped in 48.26s ==============================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I ran the following in ska3, once using all flight packages and once with this PR in PYTHONPATH:
```
acdc_check_cal ${SKA}/data/mpcrit1/mplogs/2023/NOV1323/oflsa/output/NOV1323A_proseco.pkl.gz 2023:311
```
In flight this produced a bunch of the clipping warnings, while with the PR there were no warnings. I diffed the text and HTML outputs of the tools and found no diffs.

