### PR TITLE
[Speedy]: fix ellipsis in ACAImage and squash warning about integer arrays

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -195,7 +195,9 @@ class ACAImage(np.ndarray):
             )
             aca_coords = True
 
-        out_rc = [None, None]  # New [row0, col0]
+        # These are new [row0, col0] values for the __getitem__ output. If either is left at None
+        # then the downstream code uses the original row0 or col0 value, respectively.
+        out_rc = [None, None]
 
         if isinstance(item, (int, np.integer)):
             item = (item,)

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -219,7 +219,7 @@ class ACAImage(np.ndarray):
                             else np.clip(it.stop - rc0, 0, shape[i])
                         )
                         item[i] = slice(start, stop, it.step)
-                    else:
+                    elif it is not ...:
                         item[i] = it - rc0
                         if np.any(item[i] < 0) or np.any(item[i] >= shape[i]):
                             raise IndexError(
@@ -234,7 +234,7 @@ class ACAImage(np.ndarray):
                     if it.start is not None:
                         rc_off = it.start if it.start >= 0 else shape[i] + it.start
                         out_rc[i] = rc0 + rc_off
-                else:
+                elif it is not ...:
                     it = np.array(it)
                     rc_off = np.where(it >= 0, it, shape[i] + it)
                     out_rc[i] = rc0 + rc_off

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -396,7 +396,7 @@ class _AcaImageHeaderDecom:
         -------
         dict
         """
-        bits = np.unpackbits(np.array(_unpack("BBBbbBB", bits), dtype=np.uint8))
+        bits = np.unpackbits(np.array(_unpack("BBBBBBB", bits), dtype=np.uint8))
         return {
             "IMGFID": bool(bits[0]),
             "IMGNUM": _packbits(bits[1:4]),
@@ -428,7 +428,7 @@ class _AcaImageHeaderDecom:
         -------
         dict
         """
-        bits = _unpack("BbbbbBB", bits)
+        bits = _unpack("BBbbbBB", bits)
         c = np.unpackbits(np.array(bits[:2], dtype=np.uint8))
         return {
             # do we want these?

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -428,20 +428,20 @@ class _AcaImageHeaderDecom:
         -------
         dict
         """
-        bits = _unpack("BBbbbBB", bits)
-        c = np.unpackbits(np.array(bits[:2], dtype=np.uint8))
+        values = _unpack("BBbbbbB", bits)
+        c = np.unpackbits(np.array(values[:2], dtype=np.uint8))
         return {
             # do we want these?
-            # 'FID2': bool(bits[0]),
-            # 'IMGNUM2': _packbits(bits[1:4]),
-            # 'IMGFUNC2': _packbits(bits[4:6]),
+            # 'FID2': bool(values[0]),
+            # 'IMGNUM2': _packbits(values[1:4]),
+            # 'IMGFUNC2': _packbits(values[4:6]),
             "BGDRMS": _packbits(c[6:16]),
-            "TEMPCCD": bits[2],
-            "TEMPHOUS": bits[3],
-            "TEMPPRIM": bits[4],
-            "TEMPSEC": bits[5],
-            "BGDSTAT": bits[6],
-            "BGDSTAT_PIXELS": np.unpackbits(np.array(bits[-1:], dtype=np.uint8)[-1:]),
+            "TEMPCCD": values[2],
+            "TEMPHOUS": values[3],
+            "TEMPPRIM": values[4],
+            "TEMPSEC": values[5],
+            "BGDSTAT": values[6],
+            "BGDSTAT_PIXELS": np.unpackbits(np.array(values[-1:], dtype=np.uint8)[-1:]),
         }
 
     @staticmethod

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -162,8 +162,7 @@ def test_ellipsis():
 
     row0 = 11
     col0 = 22
-    size = 8
-    inp = np.random.uniform(size=(size, size))
+    inp = np.arange(64).reshape(8, 8)
     img = aca_image.ACAImage(inp, row0=row0, col0=col0)
 
     assert np.all(img[...] == inp)

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -157,6 +157,54 @@ def test_slice():
     assert np.all(a2 == im80)
 
 
+def test_ellipsis():
+    from chandra_aca import aca_image
+
+    row0 = 11
+    col0 = 22
+    size = 8
+    inp = np.random.uniform(size=(size, size))
+    img = aca_image.ACAImage(inp, row0=row0, col0=col0)
+
+    assert np.all(img[...] == inp)
+    assert img[...].row0 == row0
+    assert img[...].col0 == col0
+
+    img2 = img[-1, ...]
+    assert np.all(img2 == inp[-1, ...])
+    # assert img2.row0 == img[size - 1 , ...].row0  # Fails independently of this PR
+    assert img2.col0 == col0
+
+    img2 = img[1, ...]
+    assert np.all(img2 == inp[1, ...])
+    assert img2.row0 == row0 + 1
+    assert img2.col0 == col0
+
+    img2 = img[..., -2]
+    assert np.all(img2 == inp[..., -2])
+    assert img2.row0 == row0
+    # assert img2.col0 == img[..., size - 2]  # fails independently of this PR
+
+    img2 = img[..., 2]
+    assert np.all(img[..., 2] == inp[..., 2])
+    assert img[..., 2].row0 == row0
+    assert img[..., 2].col0 == col0 + 2
+
+    img2 = img.aca[row0 + 1, ...]
+    assert np.all(img2 == inp[1, ...])
+    assert img2.row0 == row0 + 1
+    assert img2.col0 == col0
+
+    img2 = img.aca[..., col0 + 2]
+    assert np.all(img2 == inp[..., 2])
+    assert img2.row0 == row0
+    assert img2.col0 == col0 + 2
+
+    with pytest.raises(IndexError):
+        # an index can only have a single ellipsis
+        img[..., ...]
+
+
 def test_slice_list():
     a = ACAImage(im6, row0=1, col0=2)
     r = [1, 2, 3]


### PR DESCRIPTION
## Description

This PRs fixes issues found in python 3.11 (Speedy):
- ellipsis is not supported in slicing `ACAImage`
- a warning is issued in maude_decom when casting integer arrays (#166)

**NOTE**: while working on this, I found some unrelated issues I have not fixed. in this PR

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #166 
Fixes #165 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by @taldcroft
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
