### PR TITLE
Fix indexing issues

### DIFF
--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -47,6 +47,48 @@ def test_row_col_set():
     assert type(a.col0) is np.int64
 
 
+def test_negative_index():
+    img = ACAImage(im8, row0=11, col0=-22)
+    img2 = img[-3, :]
+    assert np.all(img2 == im8[-3, :])
+    assert img2.row0 == img[5, :].row0
+    assert img2.col0 == img.col0
+
+    img2 = img[-3:-1, :]
+    assert np.all(img2 == im8[-3:-1, :])
+    assert img2.row0 == img[5:7, :].row0
+    assert img2.col0 == img.col0
+
+
+def test_out_of_bounds():
+    img = ACAImage(im8, row0=11, col0=-22)
+    # OK in slice
+    img2 = img.aca[10:13, -24:-20]
+    assert img2.row0 == 11
+    assert img2.col0 == -22
+    assert img2.shape == (2, 2)
+
+    with pytest.raises(
+        IndexError, match="index 10 is out of bounds for axis 0 with limits 11:19"
+    ):
+        img.aca[10, :]
+
+    with pytest.raises(
+        IndexError, match="index 10 is out of bounds for axis 1 with limits -22:-14"
+    ):
+        img.aca[:, 10]
+
+    with pytest.raises(
+        IndexError, match="index -10 is out of bounds for axis 0 with size 8"
+    ):
+        img[[-10, -1, 2], :]
+
+    with pytest.raises(
+        IndexError, match="index -9 is out of bounds for axis 1 with size 8"
+    ):
+        img[:, -9]
+
+
 def test_meta_set():
     a = ACAImage(im6)
     a.ATTR = 10


### PR DESCRIPTION
## Description

This PR does two things
- Ensure that the `row0` and `col0` attributes are correct for certain indexing/slicing operations
- Raise `IndexError` for out-of-bounds index values. Previously a result was returned but it was wrong.

Fixes #168

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  chandra_aca git:(fix-indexing-issues) ✗ git rev-parse HEAD          
81957d9277b286e1a08a003ae3bd82bce4807457
(ska3) ➜  chandra_aca git:(fix-indexing-issues) pytest
===================================================== test session starts =====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 204 items                                                                                                           

chandra_aca/tests/test_aca_image.py ................                                                                    [  7%]
chandra_aca/tests/test_all.py ........................                                                                  [ 19%]
chandra_aca/tests/test_attitude.py .............................................................                        [ 49%]
chandra_aca/tests/test_dark_model.py ....                                                                               [ 51%]
chandra_aca/tests/test_drift.py ..........................                                                              [ 64%]
chandra_aca/tests/test_maude_decom.py ..................                                                                [ 73%]
chandra_aca/tests/test_planets.py ...............                                                                       [ 80%]
chandra_aca/tests/test_psf.py ...                                                                                       [ 81%]
chandra_aca/tests/test_residuals.py ss...                                                                               [ 84%]
chandra_aca/tests/test_star_probs.py ................................                                                   [100%]

=============================================== 202 passed, 2 skipped in 43.65s ===============================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
