### PR TITLE
Use proseco acq candidate mask for ACA plot (bad_acq_stars)

### DIFF
--- a/chandra_aca/plot.py
+++ b/chandra_aca/plot.py
@@ -264,11 +264,11 @@ def plot_stars(
         A Quaternion compatible attitude for the pointing
     catalog : Records describing catalog.  Must be astropy table compatible.
         Required fields are ['idx', 'type', 'yang', 'zang', 'halfw']
-    stars : astropy table compatible set of agasc records of stars
+    stars : astropy table compatible set of AGASC records of stars
         Required fields are ['RA_PMCORR', 'DEC_PMCORR', 'MAG_ACA', 'MAG_ACA_ERR'].
-        If bad_acq_stars will be called (bad_stars is None), additional required fields
-        ['CLASS', 'ASPQ1', 'ASPQ2', 'ASPQ3', 'VAR', 'POS_ERR']
-        If stars is None, stars will be fetched from the AGASC for the
+        If ``bad_stars`` is None, additional required fields are
+        ['CLASS', 'COLOR1', 'ASPQ1', 'ASPQ2', 'VAR', 'POS_ERR']
+        If ``stars`` is None, stars will be fetched from the AGASC for the
         supplied attitude.
     title
         string to be used as suptitle for the figure
@@ -281,8 +281,8 @@ def plot_stars(
     grid
         boolean, plot axis grid
     bad_stars : boolean mask on 'stars' of those that don't meet minimum requirements
-        to be selected as acq stars.  If None, bad_stars will be set by a call
-        to bad_acq_stars().
+        to be selected as acq stars.  If None, ``bad_stars`` will be set by calling
+        ``bad_acq_stars()``.
     plot_keepout
         plot CCD area to be avoided in star selection (default=False)
     ax
@@ -477,26 +477,23 @@ def _plot_planets(ax, att, date0, duration, lim0, lim1):
 
 def bad_acq_stars(stars):
     """
-    Return mask of 'bad' stars, by evaluating AGASC star parameters.
+    Return mask of 'bad' stars that are not acceptable as acquisition stars.
+
+    This is a thin wrapper around ``proseco.acq.get_acq_candidates_mask()``.
 
     Parameters
     ----------
-    stars : astropy table-compatible set of agasc records of stars. Required fields
-        are ['CLASS', 'ASPQ1', 'ASPQ2', 'ASPQ3', 'VAR', 'POS_ERR']
+    stars : astropy table-compatible set of AGASC records of stars. Required fields
+        are 'CLASS', 'MAG_ACA', 'MAG_ACA_ERR', 'COLOR1', 'ASPQ1', 'ASPQ2', 'VAR',
+        and'POS_ERR'.
 
     Returns
     -------
     boolean mask true for 'bad' stars
     """
-    return (
-        (stars["CLASS"] != 0)
-        | (stars["MAG_ACA_ERR"] > 100)
-        | (stars["POS_ERR"] > 3000)
-        | (stars["ASPQ1"] > 0)
-        | (stars["ASPQ2"] > 0)
-        | (stars["ASPQ3"] > 999)
-        | (stars["VAR"] > -9999)
-    )
+    import proseco.acq
+
+    return ~proseco.acq.get_acq_candidates_mask(stars)
 
 
 @custom_plt_rcparams


### PR DESCRIPTION
## Description

This fixes an issue where stars from AGASC 1.8 are nearly all plotted in the orange-ish color denoting a star that is not selectable as an acq star. This is currently manifested in starcheck review star catalog plots, making it somewhat difficult to evaluate the star field and catalog.

## Requires

- https://github.com/sot/proseco/pull/399

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- The filtering mask in proseco requires two new AGASC columns compared to the previous `chandra_aca.plot` code: `MAG_ACA` and `COLOR1`.
- The filtering in proseco is somewhat different from the previous code, so there will be changes in the color of plotted stars. In general the changes are for the better and accurately reflect what proseco is using in star selection.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-fido> export PYTHONPATH=/home/jeanconn/git/proseco
ska3-jeanconn-fido> git rev-parse HEAD
ab418934559da69f8a3afa55433be4d33fa596a2
ska3-jeanconn-fido> pytest
============================================== test session starts ==============================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 205 items                                                                                             

chandra_aca/tests/test_aca_image.py .................                                                     [  8%]
chandra_aca/tests/test_all.py ........................                                                    [ 20%]
chandra_aca/tests/test_attitude.py .............................................................          [ 49%]
chandra_aca/tests/test_dark_model.py ....                                                                 [ 51%]
chandra_aca/tests/test_drift.py ..........................                                                [ 64%]
chandra_aca/tests/test_maude_decom.py ..................                                                  [ 73%]
chandra_aca/tests/test_planets.py ...............                                                         [ 80%]
chandra_aca/tests/test_psf.py ...                                                                         [ 81%]
chandra_aca/tests/test_residuals.py .....                                                                 [ 84%]
chandra_aca/tests/test_star_probs.py ................................                                     [100%]

======================================== 205 passed in 87.64s (0:01:27)
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

```
(ska3) ➜  chandra_aca git:(use-proseco-acq-candidate-mask) env PYTHONPATH=/Users/aldcroft/git/proseco ipython             
Python 3.11.8 | packaged by conda-forge | (main, Feb 16 2024, 20:49:36) [Clang 16.0.6 ]

In [2]: from chandra_aca.plot import plot_stars
In [3]: plot_stars([284.097466, -37.880561, 311.969530])
Out[3]: <Figure size 1064x1064 with 1 Axes>
```
#### With this PR
<img width="280" alt="image" src="https://github.com/user-attachments/assets/2859b6f3-e3b3-4bf2-bebe-a55cb4a8fe1b">

#### With current release 4.45.1
<img width="280" alt="image" src="https://github.com/user-attachments/assets/f0b1fef4-d6d8-4fe3-82a1-1675946691ef">

#### Starcheck
On `kady` in flight ska3 environment.
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/chandra_aca/pr170/starcheck.html
```
export PYTHONPATH=/home/aldcroft/git/chandra_aca:/home/aldcroft/git/proseco
cd ~/git/starcheck  # @ master
./sandbox_starcheck -dir /data/mpcrit1/mplogs/2024/JUL2524/oflsa
# mv files to icxc www area
```
