### PR TITLE
Add some routines to get background subtracted images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.10.0
     hooks:
     - id: black
       language_version: python3.11
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -850,7 +850,7 @@ def get_aca_images(
       --------------------- ------- -----------
          IMG_BGSUB          float64  DN
          IMG_DARK           float64  DN
-         T_CCD_SMOOTH       float32  degC
+         T_CCD_SMOOTH       float64  degC
 
     where:
 

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -901,8 +901,10 @@ def get_aca_images(
     else:
         raise ValueError(f"source must be 'maude' or 'cxc', not {source}")
 
-    # Get background subtracted values if bgsub is True
-    if bgsub:
+    # Get background subtracted values if bgsub is True.
+    # There's nothing to do if there are no images (len(imgs_table) == 0),
+    # so special case that.
+    if bgsub and len(imgs_table) > 0:
         dark_data = mica.archive.aca_dark.get_dark_cal_props(
             imgs_table["TIME"].min(),
             select="nearest",
@@ -920,5 +922,11 @@ def get_aca_images(
         imgs_table["IMG_BGSUB"] = imgs_bgsub
         imgs_table["IMG_DARK"] = imgs_dark
         imgs_table["T_CCD_SMOOTH"] = t_ccds
+
+    if bgsub and len(imgs_table) == 0:
+        # Add the columns to the table even if there are no rows
+        imgs_table["IMG_BGSUB"] = np.zeros(0)
+        imgs_table["IMG_DARK"] = np.zeros(0)
+        imgs_table["T_CCD_SMOOTH"] = np.zeros(0)
 
     return imgs_table

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -901,16 +901,6 @@ def get_aca_images(
     else:
         raise ValueError(f"source must be 'maude' or 'cxc', not {source}")
 
-    # Do some unmasking until the maude_decom and aca_l0 interfaces are updated with
-    # fewer masked columns
-    imgs_table_unmasked = Table()
-    for col in imgs_table.colnames:
-        if col in ["TIME", "INTEG", "IMGROW0_8X8", "IMGCOL0_8X8"]:
-            imgs_table_unmasked[col] = imgs_table[col].data.data
-        else:
-            imgs_table_unmasked[col] = imgs_table[col]
-    imgs_table = imgs_table_unmasked
-
     # Get background subtracted values if bgsub is True
     if bgsub:
         dark_data = mica.archive.aca_dark.get_dark_cal_props(

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -858,6 +858,9 @@ def get_aca_images(
     - 'IMG_DARK': dark current image
     - 'T_CCD_SMOOTH': smoothed CCD temperature
 
+    The IMG_DARK individual values are only calculated if within the 1024x1024
+    dark current map, otherwise they are set to 0.  In practice this is not an
+    issue in that IMG and IMG_BGSUB must be within the CCD to be tracked.
 
     Parameters
     ----------

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -890,13 +890,13 @@ def get_aca_images(
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(
             imgs_table["TIME"], source=source, **maude_kwargs
         )
-    elif source == "mica":
+    elif source == "cxc":
         imgs_table = mica.archive.aca_l0.get_aca_images(start, stop)
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(
             imgs_table["TIME"], source=source
         )
     else:
-        raise ValueError(f"source must be 'maude' or 'mica', not {source}")
+        raise ValueError(f"source must be 'maude' or 'cxc', not {source}")
 
     # Do some unmasking until the maude_decom and aca_l0 interfaces are updated with
     # fewer masked columns

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -925,8 +925,8 @@ def get_aca_images(
 
     if bgsub and len(imgs_table) == 0:
         # Add the columns to the table even if there are no rows
-        imgs_table["IMG_BGSUB"] = np.zeros(0)
-        imgs_table["IMG_DARK"] = np.zeros(0)
-        imgs_table["T_CCD_SMOOTH"] = np.zeros(0)
+        imgs_table["IMG_BGSUB"] = np.zeros(shape=(0, 8, 8))
+        imgs_table["IMG_DARK"] = np.zeros(shape=(0, 8, 8))
+        imgs_table["T_CCD_SMOOTH"] = np.zeros(shape=0)
 
     return imgs_table

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -5,16 +5,11 @@ from itertools import chain, count
 from math import floor
 from pathlib import Path
 
-import mica.archive.aca_dark
-import mica.archive.aca_l0
 import numba
 import numpy as np
 import requests
 from astropy.table import Table
 from ska_helpers import retry
-
-import chandra_aca.dark_subtract
-import chandra_aca.maude_decom
 
 __all__ = ["ACAImage", "centroid_fm", "AcaPsfLibrary", "EIGHT_LABELS"]
 
@@ -840,6 +835,12 @@ class AcaPsfLibrary(object):
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_aca_image_table(start, stop, bgsub=True, source="maude", **maude_kwargs):
+    import mica.archive.aca_dark
+    import mica.archive.aca_l0
+
+    import chandra_aca.dark_subtract
+    import chandra_aca.maude_decom
+
     if source == "maude":
         imgs_table = chandra_aca.maude_decom.get_aca_images(start, stop, **maude_kwargs)
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -839,7 +839,7 @@ def get_aca_images(
     start: CxoTimeLike, stop: CxoTimeLike, bgsub=True, source="maude", **maude_kwargs
 ) -> Table:
     """
-    Get ACA images and ancillary data from either the maude or cxc data sources.
+    Get ACA images and ancillary data from either the MAUDE or CXC data sources.
 
     The returned table of ACA images and ancillary data will include the default
     columns returned by chandra_aca.maude_decom.get_aca_images or
@@ -865,16 +865,17 @@ def get_aca_images(
     Parameters
     ----------
     start : CxoTimeLike
-        start time
+        Start time.
     stop : CxoTimeLike
-        stop time (CXC sec)
+        Stop time (CXC sec).
     bgsub : bool
-        include background subtracted images in output table
+        Include background subtracted images in output table.
     source : str
         Data source for image and temperature telemetry ('maude' or 'cxc'). For 'cxc',
-        the image telemetry is from mica and temperature telemetry is from CXC L0 via cheta.
-    maude_kwargs
-        additional kwargs for maude data source
+        the image telemetry is from mica and temperature telemetry is from CXC L0 via
+        cheta.
+    **maude_kwargs
+        Additional kwargs for maude data source.
 
     Returns
     -------

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -1,46 +1,14 @@
-from functools import lru_cache
-
 import numba
 import numpy as np
 import requests.exceptions
-from astropy.table import Table, vstack
+from astropy.table import Table
 from cheta import fetch_sci
-from cxotime import CxoTime, CxoTimeLike
-from mica.archive import aca_l0
+from cxotime import CxoTimeLike
 from mica.archive.aca_dark import get_dark_cal_props
 from ska_helpers import retry
 
 from chandra_aca import maude_decom
 from chandra_aca.dark_model import dark_temp_scale_img
-
-
-def get_dark_data(time: CxoTimeLike):
-    """
-    Retrieve the dark calibration image and temperature for a given time.
-
-    This is a light wrapper around mica.archive.aca_dark.get_dark_cal_props.
-
-    Parameters
-    ----------
-    time : CxoTimeLike
-        Reference time for the dark calibration image.
-
-    Returns
-    -------
-    dc_img : np.array
-        Dark calibration image.
-    dc_tccd : float
-        Dark calibration CCD temperature.
-    """
-    dc = get_dark_cal_props(time, "nearest", include_image=True, aca_image=False)
-    dc_img = dc["image"]
-    if "t_ccd" in dc:
-        dc_tccd = dc["t_ccd"]
-    elif "ccd_temp" in dc:
-        dc_tccd = dc["ccd_temp"]
-    else:
-        raise ValueError("Dark cal must have t_ccd or ccd_temp")
-    return dc_img, dc_tccd
 
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
@@ -79,10 +47,10 @@ def get_tccd_data(start: CxoTimeLike, stop: CxoTimeLike, source="maude"):
 
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-def get_dcsub_aca_images(
+def _get_dcsub_aca_images(
     start=None,
     stop=None,
-    aca_images=None,
+    aca_image_table=None,
     t_ccd=None,
     t_ccd_times=None,
     dc_img=None,
@@ -99,7 +67,7 @@ def get_dcsub_aca_images(
         Start time of the time range. Default is None.
     stop : str, optional
         Stop time of the time range. Default is None.
-    aca_images : dict, optional
+    aca_image_table : dict, optional
         Dictionary of ACA image tables. Should be keyed by slot. Default is None.
         This is intended for testing.
     t_ccd : array-like, optional
@@ -129,58 +97,65 @@ def get_dcsub_aca_images(
         If aca_image_table is not defined or source is not 'maude' or 'mica'.
 
     """
-    if dc_img is not None:
-        assert dc_img.shape == (1024, 1024)
 
-    if dc_img is None:
-        dc_img, dc_tccd = get_dark_data(start)
-
-    if t_ccd is None:
-        t_ccd, t_ccd_times = get_tccd_data(start, stop, source=source)
-
-    if aca_images is not None:
-        # If supplied a dictionary of aca images, use that.  Should be keyed by slot.
-        # This is for testing.
-        assert isinstance(aca_images, dict)
-        # For each slot, require aca_image have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME
-        for slot in aca_images:
-            assert "IMG" in aca_images[slot].colnames
-            assert "IMGROW0_8X8" in aca_images[slot].colnames
-            assert "IMGCOL0_8X8" in aca_images[slot].colnames
-            assert "TIME" in aca_images[slot].colnames
-            # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
-            assert hasattr(aca_images[slot]["IMGROW0_8X8"], "mask")
-            assert hasattr(aca_images[slot]["IMGCOL0_8X8"], "mask")
-        imgs = aca_images.copy()
+    if aca_image_table is not None:
+        # If supplied an image table, use that, but confirm it has the right pieces.
+        assert type(aca_image_table) is Table
+        # Require aca_image_table have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME
+        assert "IMG" in aca_image_table.colnames
+        assert "IMGROW0_8X8" in aca_image_table.colnames
+        assert "IMGCOL0_8X8" in aca_image_table.colnames
+        assert "TIME" in aca_image_table.colnames
+        # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
+        assert hasattr(aca_image_table["IMGROW0_8X8"], "mask")
+        assert hasattr(aca_image_table["IMGCOL0_8X8"], "mask")
+        # Make a copy so we don't modify the input table
+        img_table = aca_image_table.copy()
     elif source == "maude":
-        imgs = get_maude_images(start, stop)
+        if start is None or stop is None:
+            raise ValueError("start and stop must be defined for maude source")
+        img_table = maude_decom.get_aca_images(start, stop)
     elif source == "mica":
-        imgs = get_mica_images(start, stop)
+        raise NotImplementedError("mica source not yet implemented")
     else:
         raise ValueError(
             "aca_image_table must be defined or source must be maude or mica"
         )
 
-    imgs_bgsub = {}
-    dark_imgs = {}
-    for slot in range(8):
-        if slot not in imgs:
-            continue
-        dark_imgs[slot] = get_dark_current_imgs(
-            imgs[slot], dc_img, dc_tccd, t_ccd, t_ccd_times
+    if dc_img is not None:
+        assert dc_img.shape == (1024, 1024)
+
+    if start is None:
+        start = img_table["TIME"].min()
+    if stop is None:
+        stop = img_table["TIME"].max()
+
+    if dc_img is None:
+        dark_data = get_dark_cal_props(
+            start, select="nearest", include_image=True, aca_image=False
         )
-        img_col = "IMG"
-        imgs_bgsub[slot] = imgs[slot][img_col] - dark_imgs[slot]
-        imgs_bgsub[slot].clip(0, None)
-        if full_table:
-            imgs[slot]["IMGBGSUB"] = imgs_bgsub[slot]
-            imgs[slot]["IMGDARK"] = dark_imgs[slot]
-            imgs[slot]["AACCCDPT"] = np.interp(imgs[slot]["TIME"], t_ccd_times, t_ccd)
+        dc_img = dark_data["image"]
+        dc_tccd = dark_data["ccd_temp"]
+
+    if t_ccd is None:
+        t_ccd, t_ccd_times = get_tccd_data(start, stop, source=source)
+
+    imgs_bgsub = {}
+    imgs_dark = {}
+
+    imgs_dark = get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times)
+    imgs_bgsub = img_table["IMG"] - imgs_dark
+    imgs_bgsub.clip(0, None)
+
+    if full_table:
+        img_table["IMGBGSUB"] = imgs_bgsub
+        img_table["IMGDARK"] = imgs_dark
+        img_table["AACCCDPT"] = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
 
     if not full_table:
         return imgs_bgsub
     else:
-        return imgs
+        return img_table
 
 
 def get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times):
@@ -266,122 +241,11 @@ def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
     return dark_img
 
 
-@lru_cache(maxsize=2)
-def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike, cols=None):
-    """
-    Get ACA images from mica for a given time range.
-
-    These mica images are centered in the 8x8 images via the centered_8x8=True option
-    to aca_l0.get_slot_data to match the maude images.
-
-    Parameters
-    ----------
-    start : CxoTimeLike
-        Start time of the time range.
-    stop : CxoTimeLike
-        Stop time of the time range.
-
-    Returns
-    -------
-    dict
-        dict with a astropy.table of ACA image data for each slot.
-
-    """
-    if cols is None:
-        cols = [
-            "TIME",
-            "QUALITY",
-            "IMGFUNC1",
-            "IMGRAW",
-            "IMGSIZE",
-            "IMGROW0",
-            "IMGCOL0",
-            "BGDAVG",
-            "INTEG",
-        ]
-    else:
-        for col in ["TIME", "IMGRAW", "IMGROW0", "IMGCOL0"]:
-            if col not in cols:
-                cols.append(col)
-
-    slot_data = {}
-    for slot in range(8):
-        slot_data[slot] = aca_l0.get_slot_data(
-            start,
-            stop,
-            imgsize=[4, 6, 8],
-            slot=slot,
-            columns=cols,
-            centered_8x8=True,
-        )
-        slot_data[slot] = Table(slot_data[slot])
-
-        # Rename and rejigger colums to match maude
-        IMGROW0_8X8 = slot_data[slot]["IMGROW0"].copy()
-        IMGCOL0_8X8 = slot_data[slot]["IMGCOL0"].copy()
-        IMGROW0_8X8[slot_data[slot]["IMGSIZE"] == 6] -= 1
-        IMGCOL0_8X8[slot_data[slot]["IMGSIZE"] == 6] -= 1
-        IMGROW0_8X8[slot_data[slot]["IMGSIZE"] == 4] -= 2
-        IMGCOL0_8X8[slot_data[slot]["IMGSIZE"] == 4] -= 2
-        slot_data[slot]["IMGROW0_8X8"] = IMGROW0_8X8
-        slot_data[slot]["IMGCOL0_8X8"] = IMGCOL0_8X8
-        slot_data[slot].rename_column("IMGRAW", "IMG")
-
-    return slot_data
-
-
-@retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-@lru_cache(maxsize=2)
-def get_maude_images(start: CxoTimeLike, stop: CxoTimeLike, fetch_limit_hours=100):
-    """
-    Get ACA images from MAUDE for a given time range.
-
-    Parameters
-    ----------
-    start : CxoTimeLike
-        Start time of the time range.
-    stop : CxoTimeLike
-        Stop time of the time range.
-    fetch_limit_hours : int
-        Maximum number of hours to fetch from MAUDE in one go.
-
-    Returns
-    -------
-    dict
-        dict with a astropy.table of ACA image data for each slot.
-    """
-    tstart = CxoTime(start).secs
-    tstop = CxoTime(stop).secs
-
-    if tstop - tstart > fetch_limit_hours * 60 * 60:
-        raise ValueError("Time range too large for maude fetch, limit is 100 hours")
-
-    slot_chunks = []
-    # Break maude fetches into max 3 hour chunks required by maude_decom fetch
-    for mstart in np.arange(tstart, tstop, 60 * 60 * 3):
-        mstop = np.min([tstop, mstart + 60 * 60 * 3])
-        # Add a retry here if necessary
-
-        imgs = maude_decom.get_aca_images(mstart, mstop)
-        slot_chunks.append(imgs)
-    slot_chunks = vstack(slot_chunks)
-
-    slot_data = {}
-    for slot in range(8):
-        slot_data[slot] = slot_chunks[slot_chunks["IMGNUM"] == slot]
-
-    return slot_data
-
-
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_aca_images(
     start=None,
     stop=None,
-    aca_images=None,
-    t_ccd=None,
-    t_ccd_times=None,
-    dc_img=None,
-    dc_tccd=None,
+    aca_image_table=None,
     source="maude",
 ):
     """
@@ -395,14 +259,6 @@ def get_aca_images(
         Stop time of the time range. Default is None.
     aca_images : dict, optional
         Dictionary of ACA images. Should be keyed by slot. Default is None.
-    t_ccd : array-like, optional
-        Array of CCD temperatures. Default is None.
-    t_ccd_times : array-like, optional
-        Array of CCD temperature times. Default is None.
-    dc_img : array-like, optional
-        Dark current image. Default is None.
-    dc_tccd : float, optional
-        Dark current CCD temperature. Default is None.
     source : str, optional
         Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
 
@@ -414,18 +270,13 @@ def get_aca_images(
     Raises
     ------
     ValueError
-        If the dark calibration does not have t_ccd or ccd_temp.
         If aca_image_table is not defined or source is not 'maude' or 'mica'.
 
     """
-    return get_dcsub_aca_images(
+    return _get_dcsub_aca_images(
         start=start,
         stop=stop,
-        aca_images=aca_images,
-        t_ccd=t_ccd,
-        t_ccd_times=t_ccd_times,
-        dc_img=dc_img,
-        dc_tccd=dc_tccd,
+        aca_image_table=aca_image_table,
         source=source,
         full_table=True,
     )

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -12,10 +12,264 @@ from chandra_aca import maude_decom
 from chandra_aca.dark_model import dark_temp_scale_img
 
 
-@lru_cache(maxsize=2)
-def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike):
+def get_dark_data(time: CxoTimeLike):
     """
-    Get ACA images from MICA for a given time range.
+    Retrieve the dark calibration image and temperature for a given time.
+
+    This is a light wrapper around mica.archive.aca_dark.get_dark_cal_props.
+
+    Parameters
+    ----------
+    time : CxoTimeLike
+        Reference time for the dark calibration image.
+
+    Returns
+    -------
+    dc_img : np.array
+        Dark calibration image.
+    dc_tccd : float
+        Dark calibration CCD temperature.
+    """
+    dc = get_dark_cal_props(time, "nearest", include_image=True, aca_image=False)
+    dc_img = dc["image"]
+    if "t_ccd" in dc:
+        dc_tccd = dc["t_ccd"]
+    elif "ccd_temp" in dc:
+        dc_tccd = dc["ccd_temp"]
+    else:
+        raise ValueError("Dark cal must have t_ccd or ccd_temp")
+    return dc_img, dc_tccd
+
+
+def get_tccd_data(start: CxoTimeLike, stop: CxoTimeLike, source="maude"):
+    """
+    Get the CCD temperature for a given time range.
+
+    This is a light wrapper around cheta.fetch_sci.Msid("aacccdpt", start, stop).
+
+    Parameters
+    ----------
+    start : CxoTimeLike
+        Start time of the time range.
+    stop : CxoTimeLike
+        Stop time of the time range.
+    source : str, optional
+        Source of the CCD temperature data. If 'maude', override the fetch_sci data source
+        to 'maude allow_subset=False'. Else, use the cheta default.
+
+    Returns
+    -------
+    t_ccd : np.array
+        CCD temperature values.
+    t_ccd_times : np.array
+        Times corresponding to the CCD temperature values.
+    """
+    if source == "maude":
+        # Override the data_source to be explicit about maude source.
+        with fetch_sci.data_source("maude allow_subset=False"):
+            dat = fetch_sci.Msid("aacccdpt", start, stop)
+    else:
+        dat = fetch_sci.Msid("aacccdpt", start, stop)
+    t_ccd = dat.vals
+    t_ccd_times = dat.times
+    return t_ccd, t_ccd_times
+
+
+def get_dcsub_aca_images(
+    start=None,
+    stop=None,
+    aca_images=None,
+    t_ccd=None,
+    t_ccd_times=None,
+    dc_img=None,
+    dc_tccd=None,
+    source="maude",
+    full_table=False,
+):
+    """
+    Get dark current subtracted ACA images for a given time range.
+
+    Parameters
+    ----------
+    start : str, optional
+        Start time of the time range. Default is None.
+    stop : str, optional
+        Stop time of the time range. Default is None.
+    aca_images : dict, optional
+        Dictionary of ACA image tables. Should be keyed by slot. Default is None.
+        This is intended for testing.
+    t_ccd : array-like, optional
+        Array of CCD temperatures. Default is None.
+    t_ccd_times : array-like, optional
+        Array of CCD temperature times. Default is None.
+    dc_img : array-like, optional
+        Dark current image. Default is None.
+    dc_tccd : float, optional
+        Dark current CCD temperature. Default is None.
+    source : str, optional
+        Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
+    full_table : bool, optional
+        If True, return the full table of ACA images with dark and bgsub columns.
+
+    Returns
+    -------
+    dict
+        If full_table - dictionary of aca slot data keyed by slot including raw and
+        dark current subtracted images.
+        If not full_table - dictionary of dark current subtracted ACA images keyed by slot.
+
+    Raises
+    ------
+    ValueError
+        If the dark calibration does not have t_ccd or ccd_temp.
+        If aca_image_table is not defined or source is not 'maude' or 'mica'.
+
+    """
+    if dc_img is not None:
+        assert dc_img.shape == (1024, 1024)
+
+    if dc_img is None:
+        dc_img, dc_tccd = get_dark_data(start)
+
+    if t_ccd is None:
+        t_ccd, t_ccd_times = get_tccd_data(start, stop, source=source)
+
+    if aca_images is not None:
+        # If supplied a dictionary of aca images, use that.  Should be keyed by slot.
+        # This is for testing.
+        assert isinstance(aca_images, dict)
+        # For each slot, require aca_image have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME
+        for slot in aca_images:
+            assert "IMG" in aca_images[slot].colnames
+            assert "IMGROW0_8X8" in aca_images[slot].colnames
+            assert "IMGCOL0_8X8" in aca_images[slot].colnames
+            assert "TIME" in aca_images[slot].colnames
+            # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
+            assert hasattr(aca_images[slot]["IMGROW0_8X8"], "mask")
+            assert hasattr(aca_images[slot]["IMGCOL0_8X8"], "mask")
+        imgs = aca_images.copy()
+    elif source == "maude":
+        imgs = get_maude_images(start, stop)
+    elif source == "mica":
+        imgs = get_mica_images(start, stop)
+    else:
+        raise ValueError(
+            "aca_image_table must be defined or source must be maude or mica"
+        )
+
+    imgs_bgsub = {}
+    dark_imgs = {}
+    for slot in range(8):
+        if slot not in imgs:
+            continue
+        dark_imgs[slot] = get_dark_current_imgs(
+            imgs[slot], dc_img, dc_tccd, t_ccd, t_ccd_times
+        )
+        img_col = "IMG"
+        imgs_bgsub[slot] = imgs[slot][img_col] - dark_imgs[slot]
+        imgs_bgsub[slot].clip(0, None)
+        if full_table:
+            imgs[slot]["IMGBGSUB"] = imgs_bgsub[slot]
+            imgs[slot]["IMGDARK"] = dark_imgs[slot]
+            imgs[slot]["AACCCDPT"] = np.interp(imgs[slot]["TIME"], t_ccd_times, t_ccd)
+
+    if not full_table:
+        return imgs_bgsub
+    else:
+        return imgs
+
+
+def get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times):
+    """
+    Get the scaled dark current values for a table of ACA images.
+
+
+    Parameters
+    ----------
+    img_table : astry.table.Table
+        A table containing information about the images.
+    dc_img : 1024x1024 array
+        The dark calibration image.
+    dc_tccd : float
+        The reference temperature of the dark calibration image.
+    t_ccd : array
+        The temperature values covering the time range of the img_table.
+    t_ccd_times : type
+        The corresponding times for the temperature values.
+
+    Returns
+    -------
+    dark : np.array
+        An array containing the temperature scaled dark current for each ACA image
+        in the img_table in e-/s.
+
+    """
+    assert dc_img.shape == (1024, 1024)
+    assert len(t_ccd) == len(t_ccd_times)
+
+    dark_raw = get_dark_backgrounds(
+        dc_img,
+        img_table["IMGROW0_8X8"].data.filled(1025),
+        img_table["IMGCOL0_8X8"].data.filled(1025),
+    )
+    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
+
+    dark = np.zeros((len(dark_raw), 8, 8), dtype=np.float64)
+
+    # Scale the dark current at each dark cal 8x8 image to the ccd temperature and e-/s
+    for i, (eight, t_ccd_i, img) in enumerate(
+        zip(dark_raw, dt_ccd, img_table, strict=True)
+    ):
+        img_sc = dark_temp_scale_img(eight, dc_tccd, t_ccd_i)
+        # Default to using 1.696 integ time if not present in the image table
+        integ = img["INTEG"] if "INTEG" in img.colnames else 1.696
+        dark[i] = img_sc * integ / 5
+
+    return dark
+
+
+def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
+    """
+    Get the dark background for a stack/table of ACA image.
+
+    Parameters
+    ----------
+    raw_dark_img : np.array
+        The dark calibration image.
+    imgrow0 : np.array
+        The row of the ACA image.
+    imgcol0 : np.array
+        The column of the ACA image.
+    size : int, optional
+        The size of the ACA image. Default is 8.
+
+    Returns
+    -------
+    dark_img : np.array
+        The dark backgrounds for the ACA images.
+    """
+
+    # Borrowed from the agasc code
+    @numba.jit(nopython=True)
+    def staggered_aca_slice(array_in, array_out, row, col):
+        for i in np.arange(len(row)):
+            if row[i] + size < 1024 and col[i] + size < 1024:
+                array_out[i] = array_in[row[i] : row[i] + size, col[i] : col[i] + size]
+
+    dark_img = np.zeros([len(imgrow0), size, size], dtype=np.float64)
+    staggered_aca_slice(
+        raw_dark_img.astype(float), dark_img, 512 + imgrow0, 512 + imgcol0
+    )
+    return dark_img
+
+
+@lru_cache(maxsize=2)
+def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike, cols=None):
+    """
+    Get ACA images from mica for a given time range.
+
+    These mica images are centered in the 8x8 images via the centered_8x8=True option
+    to aca_l0.get_slot_data to match the maude images.
 
     Parameters
     ----------
@@ -30,6 +284,23 @@ def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike):
         dict with a astropy.table of ACA image data for each slot.
 
     """
+    if cols is None:
+        cols = [
+            "TIME",
+            "QUALITY",
+            "IMGFUNC1",
+            "IMGRAW",
+            "IMGSIZE",
+            "IMGROW0",
+            "IMGCOL0",
+            "BGDAVG",
+            "INTEG",
+        ]
+    else:
+        for col in ["TIME", "IMGRAW", "IMGROW0", "IMGCOL0"]:
+            if col not in cols:
+                cols.append(col)
+
     slot_data = {}
     for slot in range(8):
         slot_data[slot] = aca_l0.get_slot_data(
@@ -37,13 +308,7 @@ def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike):
             stop,
             imgsize=[4, 6, 8],
             slot=slot,
-            columns=[
-                "TIME",
-                "IMGRAW",
-                "IMGSIZE",
-                "IMGROW0",
-                "IMGCOL0",
-            ],
+            columns=cols,
             centered_8x8=True,
         )
         slot_data[slot] = Table(slot_data[slot])
@@ -102,7 +367,7 @@ def get_maude_images(start: CxoTimeLike, stop: CxoTimeLike, fetch_limit_hours=10
     return slot_data
 
 
-def get_dcsub_aca_images(
+def get_aca_images(
     start=None,
     stop=None,
     aca_images=None,
@@ -113,7 +378,8 @@ def get_dcsub_aca_images(
     source="maude",
 ):
     """
-    Get dark current subtracted ACA images for a given time range.
+    Get aca images for a given time range.
+
 
     Parameters
     ----------
@@ -146,141 +412,14 @@ def get_dcsub_aca_images(
         If aca_image_table is not defined or source is not 'maude' or 'mica'.
 
     """
-    if dc_img is not None:
-        assert dc_img.shape == (1024, 1024)
-
-    if dc_img is None:
-        dc = get_dark_cal_props(start, "nearest", include_image=True, aca_image=False)
-        dc_img = dc["image"]
-        if "t_ccd" in dc:
-            dc_tccd = dc["t_ccd"]
-        elif "ccd_temp" in dc:
-            dc_tccd = dc["ccd_temp"]
-        else:
-            raise ValueError("Dark cal must have t_ccd or ccd_temp")
-
-    if t_ccd is None:
-        if source == "maude":
-            with fetch_sci.data_source("maude allow_subset=False"):
-                dat = fetch_sci.Msid("aacccdpt", start, stop)
-        else:
-            with fetch_sci.data_source("cxc"):
-                dat = fetch_sci.Msid("aacccdpt", start, stop)
-        t_ccd = dat.vals
-        t_ccd_times = dat.times
-
-    if aca_images is not None:
-        # If supplied a dictionary of aca images, use that.  Should be keyed by slot.
-        # This is for testing.
-        assert isinstance(aca_images, dict)
-        # For each slot, require aca_image have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME
-        for slot in aca_images:
-            assert "IMG" in aca_images[slot].colnames
-            assert "IMGROW0_8X8" in aca_images[slot].colnames
-            assert "IMGCOL0_8X8" in aca_images[slot].colnames
-            assert "TIME" in aca_images[slot].colnames
-            # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
-            assert hasattr(aca_images[slot]["IMGROW0_8X8"], "mask")
-            assert hasattr(aca_images[slot]["IMGCOL0_8X8"], "mask")
-        imgs = aca_images
-    elif source == "maude":
-        imgs = get_maude_images(start, stop)
-    elif source == "mica":
-        imgs = get_mica_images(start, stop)
-    else:
-        raise ValueError(
-            "aca_image_table must be defined or source must be maude or mica"
-        )
-
-    imgs_bgsub = {}
-    dark_imgs = {}
-    for slot in range(8):
-        if slot not in imgs:
-            continue
-        dark_imgs[slot] = get_dark_current_imgs(
-            imgs[slot], dc_img, dc_tccd, t_ccd, t_ccd_times
-        )
-        img_col = "IMG"
-        imgs_bgsub[slot] = imgs[slot][img_col] - dark_imgs[slot]
-        imgs_bgsub[slot].clip(0, None)
-
-    return imgs_bgsub
-
-
-def get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times):
-    """
-    Get the scaled dark current values for a table of ACA images.
-
-    Parameters
-    ----------
-    img_table : astry.table.Table
-        A table containing information about the images.
-    dc_img : 1024x1024 array
-        The dark calibration image.
-    dc_tccd : float
-        The reference temperature of the dark calibration image.
-    t_ccd : array
-        The temperature values for the time range of the img_table.
-    t_ccd_times : type
-        The corresponding times for the temperature values.
-
-    Returns
-    -------
-    dark : np.array
-        An array containing the temperature scaled dark current for each ACA image
-        in the img_table in e-/s.
-
-    """
-    assert dc_img.shape == (1024, 1024)
-    assert len(t_ccd) == len(t_ccd_times)
-
-    dark_raw = get_dark_backgrounds(
-        dc_img,
-        img_table["IMGROW0_8X8"].data.filled(1025),
-        img_table["IMGCOL0_8X8"].data.filled(1025),
+    return get_dcsub_aca_images(
+        start=start,
+        stop=stop,
+        aca_images=aca_images,
+        t_ccd=t_ccd,
+        t_ccd_times=t_ccd_times,
+        dc_img=dc_img,
+        dc_tccd=dc_tccd,
+        source=source,
+        full_table=True,
     )
-    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
-
-    dark = np.zeros((len(dark_raw), 8, 8), dtype=np.float64)
-
-    # Scale the dark current at each dark cal 8x8 image to the ccd temperature and e-/s
-    for i, (eight, t_ccd_i) in enumerate(zip(dark_raw, dt_ccd, strict=True)):
-        img_sc = dark_temp_scale_img(eight, dc_tccd, t_ccd_i)
-        # Note that this just uses standard integration time of 1.696 sec
-        dark[i] = img_sc * 1.696 / 5
-
-    return dark
-
-
-def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
-    """
-    Get the dark background for a stack/table of ACA image.
-
-    Parameters
-    ----------
-    raw_dark_img : np.array
-        The dark calibration image.
-    imgrow0 : np.array
-        The row of the ACA image.
-    imgcol0 : np.array
-        The column of the ACA image.
-    size : int, optional
-        The size of the ACA image. Default is 8.
-
-    Returns
-    -------
-    dark_img : np.array
-        The dark backgrounds for the ACA images.
-    """
-
-    @numba.jit(nopython=True)
-    def staggered_aca_slice(array_in, array_out, row, col):
-        for i in np.arange(len(row)):
-            if row[i] + size < 1024 and col[i] + size < 1024:
-                array_out[i] = array_in[row[i] : row[i] + size, col[i] : col[i] + size]
-
-    dark_img = np.zeros([len(imgrow0), size, size], dtype=np.float64)
-    staggered_aca_slice(
-        raw_dark_img.astype(float), dark_img, 512 + imgrow0, 512 + imgcol0
-    )
-    return dark_img

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -4,6 +4,7 @@ import requests.exceptions
 from astropy.table import Table
 from cheta import fetch_sci
 from cxotime import CxoTimeLike
+from mica.archive import aca_l0
 from mica.archive.aca_dark import get_dark_cal_props
 from ska_helpers import retry
 
@@ -16,7 +17,8 @@ def get_tccd_data(start: CxoTimeLike, stop: CxoTimeLike, source="maude"):
     """
     Get the CCD temperature for a given time range.
 
-    This is a light wrapper around cheta.fetch_sci.Msid("aacccdpt", start, stop).
+    This is a light wrapper around cheta.fetch_sci.Msid("aacccdpt", start, stop)
+    to handle an option to use the maude data source in an explicit way.
 
     Parameters
     ----------
@@ -30,7 +32,7 @@ def get_tccd_data(start: CxoTimeLike, stop: CxoTimeLike, source="maude"):
 
     Returns
     -------
-    t_ccd : np.array
+    t_ccd_vals : np.array
         CCD temperature values.
     t_ccd_times : np.array
         Times corresponding to the CCD temperature values.
@@ -41,60 +43,52 @@ def get_tccd_data(start: CxoTimeLike, stop: CxoTimeLike, source="maude"):
             dat = fetch_sci.Msid("aacccdpt", start, stop)
     else:
         dat = fetch_sci.Msid("aacccdpt", start, stop)
-    t_ccd = dat.vals
-    t_ccd_times = dat.times
-    return t_ccd, t_ccd_times
+    return dat.vals, dat.times
 
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def _get_dcsub_aca_images(
-    start=None,
-    stop=None,
+    start: CxoTimeLike = None,
+    stop: CxoTimeLike = None,
     aca_image_table=None,
-    t_ccd=None,
+    t_ccd_vals=None,
     t_ccd_times=None,
-    dc_img=None,
-    dc_tccd=None,
+    img_dark=None,
+    tccd_dark=None,
     source="maude",
-    full_table=False,
 ):
     """
     Get dark current subtracted ACA images for a given time range.
 
+    This private method has expanded options for unit testing.
+    Users should use get_dcsub_aca_images instead.
+
     Parameters
     ----------
-    start : str, optional
+    start : CxoTimeLike, optional
         Start time of the time range. Default is None.
-    stop : str, optional
+    stop : CxoTimeLike, optional
         Stop time of the time range. Default is None.
-    aca_image_table : dict, optional
-        Dictionary of ACA image tables. Should be keyed by slot. Default is None.
-        This is intended for testing.
-    t_ccd : array-like, optional
+    aca_image_table : astropy table of ACA images, optional
+
+    t_ccd_vals : array-like, optional
         Array of CCD temperatures. Default is None.
     t_ccd_times : array-like, optional
         Array of CCD temperature times. Default is None.
-    dc_img : array-like, optional
+    img_dark : array-like, optional
         Dark current image. Default is None.
-    dc_tccd : float, optional
+    tccd_dark : float, optional
         Dark current CCD temperature. Default is None.
     source : str, optional
         Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
-    full_table : bool, optional
-        If True, return the full table of ACA images with dark and bgsub columns.
 
     Returns
     -------
-    dict
-        If full_table - dictionary of aca slot data keyed by slot including raw and
-        dark current subtracted images.
-        If not full_table - dictionary of dark current subtracted ACA images keyed by slot.
-
-    Raises
-    ------
-    ValueError
-        If the dark calibration does not have t_ccd or ccd_temp.
-        If aca_image_table is not defined or source is not 'maude' or 'mica'.
+    astropy.table.Table
+        Table of aca image data including raw and dark current subtracted images.
+        Raw images are in column 'IMG', dark current subtracted images are in column 'IMGBGSUB',
+        dark current cut-out images are in column 'IMGDARK', and interpolated
+        CCD temperature values are in column 'AACCCDPT'.
 
     """
 
@@ -111,99 +105,104 @@ def _get_dcsub_aca_images(
         assert hasattr(aca_image_table["IMGCOL0_8X8"], "mask")
         # Make a copy so we don't modify the input table
         img_table = aca_image_table.copy()
+
+        # And it doesn't make sense to also define start and stop so raise errors if so
+        if start is not None:
+            raise ValueError("Do not define start if aca_image_table is defined")
+        if stop is not None:
+            raise ValueError("Do not define stop if aca_image_table is defined")
     elif source == "maude":
         if start is None or stop is None:
             raise ValueError("start and stop must be defined for maude source")
         img_table = maude_decom.get_aca_images(start, stop)
     elif source == "mica":
-        raise NotImplementedError("mica source not yet implemented")
+        img_table = aca_l0.get_aca_images(start, stop)
     else:
         raise ValueError(
             "aca_image_table must be defined or source must be maude or mica"
         )
 
-    if dc_img is not None:
-        assert dc_img.shape == (1024, 1024)
+    if start is None and aca_image_table is None:
+        raise ValueError("start must be defined if aca_image_table is not defined")
+    if stop is None and aca_image_table is None:
+        raise ValueError("stop must be defined if aca_image_table is not defined")
 
     if start is None:
         start = img_table["TIME"].min()
     if stop is None:
         stop = img_table["TIME"].max()
 
-    if dc_img is None:
+    if img_dark is None:
         dark_data = get_dark_cal_props(
             start, select="nearest", include_image=True, aca_image=False
         )
-        dc_img = dark_data["image"]
-        dc_tccd = dark_data["ccd_temp"]
+        img_dark = dark_data["image"]
+        tccd_dark = dark_data["ccd_temp"]
 
-    if t_ccd is None:
-        t_ccd, t_ccd_times = get_tccd_data(start, stop, source=source)
+    assert img_dark.shape == (1024, 1024)
 
-    imgs_bgsub = {}
-    imgs_dark = {}
+    if t_ccd_vals is None:
+        t_ccd_vals, t_ccd_times = get_tccd_data(start, stop, source=source)
 
-    imgs_dark = get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times)
+    imgs_dark = get_dark_current_imgs(
+        img_table, img_dark, tccd_dark, t_ccd_vals, t_ccd_times
+    )
     imgs_bgsub = img_table["IMG"] - imgs_dark
     imgs_bgsub.clip(0, None)
 
-    if full_table:
-        img_table["IMGBGSUB"] = imgs_bgsub
-        img_table["IMGDARK"] = imgs_dark
-        img_table["AACCCDPT"] = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
+    img_table["IMGBGSUB"] = imgs_bgsub
+    img_table["IMGDARK"] = imgs_dark
+    img_table["AACCCDPT"] = np.interp(img_table["TIME"], t_ccd_times, t_ccd_vals)
 
-    if not full_table:
-        return imgs_bgsub
-    else:
-        return img_table
+    return img_table
 
 
-def get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times):
+def get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals, t_ccd_times):
     """
     Get the scaled dark current values for a table of ACA images.
 
     Parameters
     ----------
-    img_table : astry.table.Table
-        A table containing information about the images.
-    dc_img : 1024x1024 array
+    img_table : astropy.table.Table
+        A table containing the ACA images and expected metadata.
+    img_dark : 1024x1024 array
         The dark calibration image.
-    dc_tccd : float
+    tccd_dark : float
         The reference temperature of the dark calibration image.
-    t_ccd : array
-        The temperature values covering the time range of the img_table.
-    t_ccd_times : type
+    t_ccd_vals : array
+        The cheta temperature values covering the time range of the img_table.
+    t_ccd_times : array
         The corresponding times for the temperature values.
 
     Returns
     -------
-    dark : np.array
+    imgs_dark : np.array
         An array containing the temperature scaled dark current for each ACA image
         in the img_table in e-/s.
 
     """
-    assert dc_img.shape == (1024, 1024)
-    assert len(t_ccd) == len(t_ccd_times)
+    assert img_dark.shape == (1024, 1024)
+    assert len(t_ccd_vals) == len(t_ccd_times)
 
-    dark_raw = get_dark_backgrounds(
-        dc_img,
+    imgs_dark_unscaled = get_dark_backgrounds(
+        img_dark,
         img_table["IMGROW0_8X8"].data.filled(1025),
         img_table["IMGCOL0_8X8"].data.filled(1025),
     )
-    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
+    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd_vals)
 
-    dark = np.zeros((len(dark_raw), 8, 8), dtype=np.float64)
+    imgs_dark = np.zeros((len(img_table), 8, 8), dtype=np.float64)
 
     # Scale the dark current at each dark cal 8x8 image to the ccd temperature and e-/s
-    for i, (eight, t_ccd_i, img) in enumerate(
-        zip(dark_raw, dt_ccd, img_table, strict=True)
+    for i, (img_dark_unscaled, t_ccd_i, img) in enumerate(
+        zip(imgs_dark_unscaled, dt_ccd, img_table, strict=True)
     ):
-        img_sc = dark_temp_scale_img(eight, dc_tccd, t_ccd_i)
+        img_scaled = dark_temp_scale_img(img_dark_unscaled, tccd_dark, t_ccd_i)
         # Default to using 1.696 integ time if not present in the image table
         integ = img["INTEG"] if "INTEG" in img.colnames else 1.696
-        dark[i] = img_sc * integ / 5
+        imgs_dark[i] = img_scaled * integ / 5
 
-    return dark
+    return imgs_dark
 
 
 def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
@@ -223,8 +222,10 @@ def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
 
     Returns
     -------
-    dark_img : np.array
-        The dark backgrounds for the ACA images.
+    imgs_dark : np.array
+        The dark backgrounds for the ACA images sampled from raw_dark_img.
+        This will have the same length as imgrow0 and imgcol0, with shape
+        (len(imgrow0), size, size).  These pixels have not been scaled.
     """
 
     # Borrowed from the agasc code
@@ -234,17 +235,17 @@ def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
             if row[i] + size < 1024 and col[i] + size < 1024:
                 array_out[i] = array_in[row[i] : row[i] + size, col[i] : col[i] + size]
 
-    dark_img = np.zeros([len(imgrow0), size, size], dtype=np.float64)
+    imgs_dark = np.zeros([len(imgrow0), size, size], dtype=np.float64)
     staggered_aca_slice(
-        raw_dark_img.astype(float), dark_img, 512 + imgrow0, 512 + imgcol0
+        raw_dark_img.astype(float), imgs_dark, 512 + imgrow0, 512 + imgcol0
     )
-    return dark_img
+    return imgs_dark
 
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-def get_aca_images(
-    start=None,
-    stop=None,
+def get_dcsub_aca_images(
+    start: CxoTimeLike = None,
+    stop: CxoTimeLike = None,
     aca_image_table=None,
     source="maude",
 ):
@@ -257,20 +258,18 @@ def get_aca_images(
         Start time of the time range. Default is None.
     stop : str, optional
         Stop time of the time range. Default is None.
-    aca_images : dict, optional
-        Dictionary of ACA images. Should be keyed by slot. Default is None.
+    aca_image_table : astropy.table.Table
+        Table including ACA images.
     source : str, optional
         Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
 
     Returns
     -------
-    dict
-        Dictionary of dark current subtracted ACA images for each slot.
-
-    Raises
-    ------
-    ValueError
-        If aca_image_table is not defined or source is not 'maude' or 'mica'.
+    astropy.table.Table
+        Table of aca image data including raw and dark current subtracted images.
+        Raw images are in column 'IMG', dark current subtracted images are in column 'IMGBGSUB',
+        dark current cut-out images are in column 'IMGDARK', and interpolated
+        CCD temperature values are in column 'AACCCDPT'.
 
     """
     return _get_dcsub_aca_images(
@@ -278,5 +277,4 @@ def get_aca_images(
         stop=stop,
         aca_image_table=aca_image_table,
         source=source,
-        full_table=True,
     )

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -2,213 +2,97 @@ import numba
 import numpy as np
 import requests.exceptions
 import scipy.signal
-from astropy.table import Table
 from cheta import fetch_sci
-from cxotime import CxoTime, CxoTimeLike
-from mica.archive import aca_l0
-from mica.archive.aca_dark import get_dark_cal_props
 from ska_helpers import retry
 from ska_numpy import smooth
 
-from chandra_aca import maude_decom
 from chandra_aca.dark_model import dark_temp_scale_img
 
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-def get_tccd_data(times: CxoTimeLike, pad=600, smooth_window=30, source="maude"):
+def get_tccd_data(
+    times, smooth_window=30, median_window=3, source="maude", maude_channel=None
+):
     """
-    Get the CCD temperature for a given time range.
+    Get the CCD temperature for given times and interpolate and smooth.
 
     This is a light wrapper around cheta.fetch_sci.Msid("aacccdpt", start, stop)
     to handle an option to use the maude data source in an explicit way.
 
     Parameters
     ----------
-    times:
+    times: np.array float of Chandra seconds
         The times for which to get the CCD temperature data.
     source : str, optional
         Source of the CCD temperature data. If 'maude', override the fetch_sci data source
         to 'maude allow_subset=False'. Else, use the cheta default.
-    pad : int, optional
-        Pad the query times by this amount in seconds. Default is 600.
-        This extra time is not included in the returned data.
+    median_window : int, optional
+        3-sample Median filter to to remove outliers.
     smooth_window : int, optional
-        3-sample Median filter and then smooth the data using a hanning window of this length.
-        Generally should not be more than pad * 2 / 32.8 .
+        Smooth the data using a hanning window of this length in samples.
+
 
     Returns
     -------
-    t_ccd_vals : np.array
+    vals : np.array
         CCD temperature values.
-    t_ccd_times : np.array
-        Times corresponding to the CCD temperature values.
     """
-    fetch_start = CxoTime(times[0]).secs
-    fetch_stop = CxoTime(times[-1]).secs
-    if pad > 0:
-        fetch_start -= pad
-        fetch_stop += pad
+
+    pad = 600  # 600 seconds default pad
+
+    # increase the pad if the smooth window is large
+    pad = np.max([smooth_window * 32.8 / 2, pad])
+
+    fetch_start = times[0] - pad
+    fetch_stop = times[-1] + pad
 
     if source == "maude":
-        # Override the data_source to be explicit about maude source.
-        with fetch_sci.data_source("maude allow_subset=False"):
+        # Override the cheta data_source to be explicit about maude source.
+        data_source = "maude allow_subset=False"
+        if maude_channel is not None:
+            data_source += f" channel={maude_channel}"
+        with fetch_sci.data_source(data_source):
             dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
     else:
         dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
 
-    xin = dat.times
     yin = dat.vals.copy()
 
-    if smooth_window > 0:
+    if median_window > 0:
         # Filter the data using a 3 point median filter from scipy
-        yin = scipy.signal.medfilt(yin, kernel_size=3)
+        yin = scipy.signal.medfilt(yin, kernel_size=median_window)
+
+    if smooth_window > 0:
         # And then smooth it with hanning and window_len = smooth_window
         yin = smooth(yin, window_len=smooth_window)
 
-    xout = CxoTime(times).secs
     # Interpolate the data to the requested times
-    vals = np.interp(xout, xin, yin)
+    vals = np.interp(times, dat.times, yin)
 
-    return vals, times
+    return vals
 
 
-@retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-def _get_dcsub_aca_images(
-    start: CxoTimeLike = None,
-    stop: CxoTimeLike = None,
-    aca_image_table=None,
-    t_ccd_vals=None,
-    t_ccd_times=None,
-    img_dark=None,
-    tccd_dark=None,
-    source="maude",
-):
-    """
-    Get dark current subtracted ACA images for a given time range.
-
-    This private method has expanded options for unit testing.
-    Users should use get_dcsub_aca_images instead.
-
-    Parameters
-    ----------
-    start : CxoTimeLike, optional
-        Start time of the time range. Default is None.
-    stop : CxoTimeLike, optional
-        Stop time of the time range. Default is None.
-    aca_image_table : astropy table of ACA images, optional
-
-    t_ccd_vals : array-like, optional
-        Array of CCD temperatures. Default is None.
-    t_ccd_times : array-like, optional
-        Array of CCD temperature times. Default is None.
-    img_dark : array-like, optional
-        Dark current image. Default is None.
-    tccd_dark : float, optional
-        Dark current CCD temperature. Default is None.
-    source : str, optional
-        Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
-
-    Returns
-    -------
-    astropy.table.Table
-        Table of aca image data including raw and dark current subtracted images.
-        Raw images are in column 'IMG', dark current subtracted images are in column 'IMGBGSUB',
-        dark current cut-out images are in column 'IMGDARK', and interpolated
-        CCD temperature values are in column 'AACCCDPT'.
-
-    """
-
-    if start is None and aca_image_table is None:
-        raise ValueError("start must be defined if aca_image_table is not defined")
-    if stop is None and aca_image_table is None:
-        raise ValueError("stop must be defined if aca_image_table is not defined")
-
-    if aca_image_table is not None:
-        # If supplied an image table, use that, but confirm it has the right pieces.
-        assert type(aca_image_table) is Table
-
-        # Require aca_image_table have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME.
-        # If this is a table of mica data that doesn't have those columns, see
-        # mica.archive.aca_l0.get_aca_images for how to get the data or use that method.
-        assert "IMG" in aca_image_table.colnames
-        assert "IMGROW0_8X8" in aca_image_table.colnames
-        assert "IMGCOL0_8X8" in aca_image_table.colnames
-        assert "TIME" in aca_image_table.colnames
-        # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
-        assert hasattr(aca_image_table["IMGROW0_8X8"], "mask")
-        assert hasattr(aca_image_table["IMGCOL0_8X8"], "mask")
-        # Make a copy so we don't modify the input table
-        img_table = aca_image_table.copy()
-
-        # And it doesn't make sense to also define start and stop so raise errors if so
-        if start is not None:
-            raise ValueError("Do not define start if aca_image_table is defined")
-        if stop is not None:
-            raise ValueError("Do not define stop if aca_image_table is defined")
-    elif source == "maude":
-        img_table = maude_decom.get_aca_images(start, stop)
-    elif source == "mica":
-        img_table = aca_l0.get_aca_images(start, stop)
-    else:
-        raise ValueError(
-            "aca_image_table must be defined or source must be maude or mica"
-        )
-
-    if start is None:
-        start = img_table["TIME"].min()
-    if stop is None:
-        stop = img_table["TIME"].max()
-
-    if img_dark is None:
-        dark_data = get_dark_cal_props(
-            start, select="nearest", include_image=True, aca_image=False
-        )
-        img_dark = dark_data["image"]
-        tccd_dark = dark_data["ccd_temp"]
-
-    assert img_dark.shape == (1024, 1024)
-
-    # if the img_table has masked values in TIME, filter the table to remove
-    # the full rows before proceeding.
-    if hasattr(img_table["TIME"], "mask"):
-        # Filter the table in place so that we can unmask/compress TIME safely
-        img_table = img_table[~img_table["TIME"].mask]
-        times = img_table["TIME"].compressed()
-    else:
-        times = img_table["TIME"]
-
-    if t_ccd_vals is None:
-        t_ccd_vals, t_ccd_times = get_tccd_data(times, source=source)
-
-    imgs_dark = get_dark_current_imgs(
-        img_table, img_dark, tccd_dark, t_ccd_vals, t_ccd_times
-    )
+def get_aca_images_bgd_sub(img_table, t_ccd_vals, img_dark, tccd_dark):
+    imgs_dark = get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals)
     imgs_bgsub = img_table["IMG"] - imgs_dark
     imgs_bgsub.clip(0, None)
 
-    img_table["IMGBGSUB"] = imgs_bgsub
-    img_table["IMGDARK"] = imgs_dark
-    img_table["AACCCDPT"] = t_ccd_vals
-
-    return img_table
+    return imgs_bgsub, imgs_dark
 
 
-def get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals, t_ccd_times):
+def get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccds):
     """
     Get the scaled dark current values for a table of ACA images.
 
     Parameters
     ----------
     img_table : astropy.table.Table
-        A table containing the ACA images and expected metadata.
     img_dark : 1024x1024 array
         The dark calibration image.
     tccd_dark : float
         The reference temperature of the dark calibration image.
-    t_ccd_vals : array
-        The cheta temperature values covering the time range of the img_table.
-    t_ccd_times : array
-        The corresponding times for the temperature values.
+    t_ccds : array
+        The cheta temperature values at the times of img_table.
 
     Returns
     -------
@@ -217,21 +101,23 @@ def get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals, t_ccd_time
         in the img_table in e-/s.
 
     """
-    assert img_dark.shape == (1024, 1024)
-    assert len(t_ccd_vals) == len(t_ccd_times)
+    if len(img_table) != len(t_ccds):
+        raise ValueError("img_table and t_ccds must have the same length")
+
+    if img_dark.shape != (1024, 1024):
+        raise ValueError("Dark image shape is not 1024x1024")
 
     imgs_dark_unscaled = get_dark_backgrounds(
         img_dark,
-        img_table["IMGROW0_8X8"].data.filled(1025),
-        img_table["IMGCOL0_8X8"].data.filled(1025),
+        img_table["IMGROW0_8X8"],
+        img_table["IMGCOL0_8X8"],
     )
-    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd_vals)
 
     imgs_dark = np.zeros((len(img_table), 8, 8), dtype=np.float64)
 
     # Scale the dark current at each dark cal 8x8 image to the ccd temperature and e-/s
     for i, (img_dark_unscaled, t_ccd_i, img) in enumerate(
-        zip(imgs_dark_unscaled, dt_ccd, img_table, strict=True)
+        zip(imgs_dark_unscaled, t_ccds, img_table, strict=True)
     ):
         img_scaled = dark_temp_scale_img(img_dark_unscaled, tccd_dark, t_ccd_i)
         # Default to using 1.696 integ time if not present in the image table
@@ -276,49 +162,3 @@ def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
         raw_dark_img.astype(float), imgs_dark, 512 + imgrow0, 512 + imgcol0
     )
     return imgs_dark
-
-
-@retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
-def get_dcsub_aca_images(
-    start: CxoTimeLike = None,
-    stop: CxoTimeLike = None,
-    aca_image_table=None,
-    source="maude",
-):
-    """
-    Get aca images for a given time range.
-
-    One must supply either aca_image_table or start and stop times.  If start and stop
-    times are supplied, an aca image table will be fetched from the maude or mica data
-    and a table will be returned that includes dark current background subtracted images
-    in one of the astropy table columns.  If an aca_image_table is supplied, the images
-    within that table will be used as the raw images, and a new table that includes
-    dark current background subtracted images will be returned.
-
-
-    Parameters
-    ----------
-    start : CxoTimeLike, optional
-        Start time of the time range. Default is None.
-    stop : CxoTimeLike, optional
-        Stop time of the time range. Default is None.
-    aca_image_table : astropy.table.Table
-        Table including ACA images.
-    source : str, optional
-        Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
-
-    Returns
-    -------
-    astropy.table.Table
-        Table of aca image data including raw and dark current subtracted images.
-        Raw images are in column 'IMG', dark current subtracted images are in column 'IMGBGSUB',
-        dark current cut-out images are in column 'IMGDARK', and interpolated
-        CCD temperature values are in column 'AACCCDPT'.
-
-    """
-    return _get_dcsub_aca_images(
-        start=start,
-        stop=stop,
-        aca_image_table=aca_image_table,
-        source=source,
-    )

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -47,6 +47,10 @@ def get_tccd_data(
         CCD temperature values.
     """
 
+    # If no times are given, return an empty array.
+    if len(times) == 0:
+        return np.array([])
+
     pad = 600  # 600 seconds default pad
 
     # increase the pad if the smooth window is large

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -1,0 +1,286 @@
+from functools import lru_cache
+
+import numba
+import numpy as np
+from astropy.table import Table, vstack
+from cheta import fetch_sci
+from cxotime import CxoTime, CxoTimeLike
+from mica.archive import aca_l0
+from mica.archive.aca_dark import get_dark_cal_props
+
+from chandra_aca import maude_decom
+from chandra_aca.dark_model import dark_temp_scale_img
+
+
+@lru_cache(maxsize=2)
+def get_mica_images(start: CxoTimeLike, stop: CxoTimeLike):
+    """
+    Get ACA images from MICA for a given time range.
+
+    Parameters
+    ----------
+    start : CxoTimeLike
+        Start time of the time range.
+    stop : CxoTimeLike
+        Stop time of the time range.
+
+    Returns
+    -------
+    dict
+        dict with a astropy.table of ACA image data for each slot.
+
+    """
+    slot_data = {}
+    for slot in range(8):
+        slot_data[slot] = aca_l0.get_slot_data(
+            start,
+            stop,
+            imgsize=[4, 6, 8],
+            slot=slot,
+            columns=[
+                "TIME",
+                "IMGRAW",
+                "IMGSIZE",
+                "IMGROW0",
+                "IMGCOL0",
+            ],
+            centered_8x8=True,
+        )
+        slot_data[slot] = Table(slot_data[slot])
+
+        # Rename and rejigger colums to match maude
+        IMGROW0_8X8 = slot_data[slot]["IMGROW0"].copy()
+        IMGCOL0_8X8 = slot_data[slot]["IMGCOL0"].copy()
+        IMGROW0_8X8[slot_data[slot]["IMGSIZE"] == 6] -= 1
+        IMGCOL0_8X8[slot_data[slot]["IMGSIZE"] == 6] -= 1
+        IMGROW0_8X8[slot_data[slot]["IMGSIZE"] == 4] -= 2
+        IMGCOL0_8X8[slot_data[slot]["IMGSIZE"] == 4] -= 2
+        slot_data[slot]["IMGROW0_8X8"] = IMGROW0_8X8
+        slot_data[slot]["IMGCOL0_8X8"] = IMGCOL0_8X8
+        slot_data[slot].rename_column("IMGRAW", "IMG")
+
+    return slot_data
+
+
+@lru_cache(maxsize=2)
+def get_maude_images(start: CxoTimeLike, stop: CxoTimeLike, fetch_limit_hours=100):
+    """
+    Get ACA images from MAUDE for a given time range.
+
+    Parameters
+    ----------
+    start : CxoTimeLike
+        Start time of the time range.
+    stop : CxoTimeLike
+        Stop time of the time range.
+    fetch_limit_hours : int
+        Maximum number of hours to fetch from MAUDE in one go.
+
+    Returns
+    -------
+    dict
+        dict with a astropy.table of ACA image data for each slot.
+    """
+    tstart = CxoTime(start).secs
+    tstop = CxoTime(stop).secs
+
+    if tstop - tstart > fetch_limit_hours * 60 * 60:
+        raise ValueError("Time range too large for maude fetch, limit is 100 hours")
+
+    slot_chunks = []
+    # Break maude fetches into max 3 hour chunks required by maude_decom fetch
+    for mstart in np.arange(tstart, tstop, 60 * 60 * 3):
+        mstop = np.min([tstop, mstart + 60 * 60 * 3])
+        imgs = maude_decom.get_aca_images(mstart, mstop)
+        slot_chunks.append(imgs)
+    slot_chunks = vstack(slot_chunks)
+
+    slot_data = {}
+    for slot in range(8):
+        slot_data[slot] = slot_chunks[slot_chunks["IMGNUM"] == slot]
+
+    return slot_data
+
+
+def get_dcsub_aca_images(
+    start=None,
+    stop=None,
+    aca_images=None,
+    t_ccd=None,
+    t_ccd_times=None,
+    dc_img=None,
+    dc_tccd=None,
+    source="maude",
+):
+    """
+    Get dark current subtracted ACA images for a given time range.
+
+    Parameters
+    ----------
+    start : str, optional
+        Start time of the time range. Default is None.
+    stop : str, optional
+        Stop time of the time range. Default is None.
+    aca_images : dict, optional
+        Dictionary of ACA images. Should be keyed by slot. Default is None.
+    t_ccd : array-like, optional
+        Array of CCD temperatures. Default is None.
+    t_ccd_times : array-like, optional
+        Array of CCD temperature times. Default is None.
+    dc_img : array-like, optional
+        Dark current image. Default is None.
+    dc_tccd : float, optional
+        Dark current CCD temperature. Default is None.
+    source : str, optional
+        Source of the ACA images. Can be 'maude' or 'mica'. Default is 'maude'.
+
+    Returns
+    -------
+    dict
+        Dictionary of dark current subtracted ACA images for each slot.
+
+    Raises
+    ------
+    ValueError
+        If the dark calibration does not have t_ccd or ccd_temp.
+        If aca_image_table is not defined or source is not 'maude' or 'mica'.
+
+    """
+    if dc_img is not None:
+        assert dc_img.shape == (1024, 1024)
+
+    if dc_img is None:
+        dc = get_dark_cal_props(start, "nearest", include_image=True, aca_image=False)
+        dc_img = dc["image"]
+        if "t_ccd" in dc:
+            dc_tccd = dc["t_ccd"]
+        elif "ccd_temp" in dc:
+            dc_tccd = dc["ccd_temp"]
+        else:
+            raise ValueError("Dark cal must have t_ccd or ccd_temp")
+
+    if t_ccd is None:
+        if source == "maude":
+            with fetch_sci.data_source("maude allow_subset=False"):
+                dat = fetch_sci.Msid("aacccdpt", start, stop)
+        else:
+            with fetch_sci.data_source("cxc"):
+                dat = fetch_sci.Msid("aacccdpt", start, stop)
+        t_ccd = dat.vals
+        t_ccd_times = dat.times
+
+    if aca_images is not None:
+        # If supplied a dictionary of aca images, use that.  Should be keyed by slot.
+        # This is for testing.
+        assert isinstance(aca_images, dict)
+        # For each slot, require aca_image have columns IMG, IMGROW0_8X8, IMGCOL0_8X8, TIME
+        for slot in aca_images:
+            assert "IMG" in aca_images[slot].colnames
+            assert "IMGROW0_8X8" in aca_images[slot].colnames
+            assert "IMGCOL0_8X8" in aca_images[slot].colnames
+            assert "TIME" in aca_images[slot].colnames
+            # require that IMGROW0_8X8 and IMGCOL0_8X8 are masked columns
+            assert hasattr(aca_images[slot]["IMGROW0_8X8"], "mask")
+            assert hasattr(aca_images[slot]["IMGCOL0_8X8"], "mask")
+        imgs = aca_images
+    elif source == "maude":
+        imgs = get_maude_images(start, stop)
+    elif source == "mica":
+        imgs = get_mica_images(start, stop)
+    else:
+        raise ValueError(
+            "aca_image_table must be defined or source must be maude or mica"
+        )
+
+    imgs_bgsub = {}
+    dark_imgs = {}
+    for slot in range(8):
+        if slot not in imgs:
+            continue
+        dark_imgs[slot] = get_dark_current_imgs(
+            imgs[slot], dc_img, dc_tccd, t_ccd, t_ccd_times
+        )
+        img_col = "IMG"
+        imgs_bgsub[slot] = imgs[slot][img_col] - dark_imgs[slot]
+        imgs_bgsub[slot].clip(0, None)
+
+    return imgs_bgsub
+
+
+def get_dark_current_imgs(img_table, dc_img, dc_tccd, t_ccd, t_ccd_times):
+    """
+    Get the scaled dark current values for a table of ACA images.
+
+    Parameters
+    ----------
+    img_table : astry.table.Table
+        A table containing information about the images.
+    dc_img : 1024x1024 array
+        The dark calibration image.
+    dc_tccd : float
+        The reference temperature of the dark calibration image.
+    t_ccd : array
+        The temperature values for the time range of the img_table.
+    t_ccd_times : type
+        The corresponding times for the temperature values.
+
+    Returns
+    -------
+    dark : np.array
+        An array containing the temperature scaled dark current for each ACA image
+        in the img_table in e-/s.
+
+    """
+    assert dc_img.shape == (1024, 1024)
+    assert len(t_ccd) == len(t_ccd_times)
+
+    dark_raw = get_dark_backgrounds(
+        dc_img,
+        img_table["IMGROW0_8X8"].data.filled(1025),
+        img_table["IMGCOL0_8X8"].data.filled(1025),
+    )
+    dt_ccd = np.interp(img_table["TIME"], t_ccd_times, t_ccd)
+
+    dark = np.zeros((len(dark_raw), 8, 8), dtype=np.float64)
+
+    # Scale the dark current at each dark cal 8x8 image to the ccd temperature and e-/s
+    for i, (eight, t_ccd_i) in enumerate(zip(dark_raw, dt_ccd, strict=True)):
+        img_sc = dark_temp_scale_img(eight, dc_tccd, t_ccd_i)
+        # Note that this just uses standard integration time of 1.696 sec
+        dark[i] = img_sc * 1.696 / 5
+
+    return dark
+
+
+def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
+    """
+    Get the dark background for a stack/table of ACA image.
+
+    Parameters
+    ----------
+    raw_dark_img : np.array
+        The dark calibration image.
+    imgrow0 : np.array
+        The row of the ACA image.
+    imgcol0 : np.array
+        The column of the ACA image.
+    size : int, optional
+        The size of the ACA image. Default is 8.
+
+    Returns
+    -------
+    dark_img : np.array
+        The dark backgrounds for the ACA images.
+    """
+
+    @numba.jit(nopython=True)
+    def staggered_aca_slice(array_in, array_out, row, col):
+        for i in np.arange(len(row)):
+            if row[i] + size < 1024 and col[i] + size < 1024:
+                array_out[i] = array_in[row[i] : row[i] + size, col[i] : col[i] + size]
+
+    dark_img = np.zeros([len(imgrow0), size, size], dtype=np.float64)
+    staggered_aca_slice(
+        raw_dark_img.astype(float), dark_img, 512 + imgrow0, 512 + imgcol0
+    )
+    return dark_img

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -73,6 +73,28 @@ def get_tccd_data(
 
 
 def get_aca_images_bgd_sub(img_table, t_ccd_vals, img_dark, tccd_dark):
+    """
+    Get the background subtracted ACA images.
+
+    Parameters
+    ----------
+    img_table : astropy.table.Table
+        The table of ACA images.
+    t_ccd_vals : np.array
+        The CCD temperature values at the times of the ACA images.
+    img_dark : np.array
+        The dark calibration image. Must be 1024x1024.
+    tccd_dark : float
+        The reference temperature of the dark calibration image.
+
+    Returns
+    -------
+    tuple (imgs_bgsub, imgs_dark)
+        imgs_bgsub : np.array
+            The background subtracted ACA images.
+        imgs_dark : np.array
+            The dark current images.
+    """
     imgs_dark = get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals)
     imgs_bgsub = img_table["IMG"] - imgs_dark
     imgs_bgsub.clip(0, None)

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -181,14 +181,20 @@ def get_dark_backgrounds(raw_dark_img, imgrow0, imgcol0, size=8):
     imgs_dark : np.array
         The dark backgrounds in e-/s for the ACA images sampled from raw_dark_img.
         This will have the same length as imgrow0 and imgcol0, with shape
-        (len(imgrow0), size, size).  These pixels have not been scaled.
+        (len(imgrow0), size, size).  These pixels have not been scaled.  Pixels
+        outside the raw_dark_img are set to 0.
     """
 
     # Borrowed from the agasc code
     @numba.jit(nopython=True)
     def staggered_aca_slice(array_in, array_out, row, col):
         for i in np.arange(len(row)):
-            if row[i] + size < 1024 and col[i] + size < 1024:
+            if (
+                row[i] >= 0
+                and row[i] + size < 1024
+                and col[i] >= 0
+                and col[i] + size < 1024
+            ):
                 array_out[i] = array_in[row[i] : row[i] + size, col[i] : col[i] + size]
 
     imgs_dark = np.zeros([len(imgrow0), size, size], dtype=np.float64)

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -524,8 +524,8 @@ def images_check_range(start, stop, img_table, *, bgsub):
             row8x8 = row["IMGROW0_8X8"]
             col8x8 = row["IMGCOL0_8X8"]
 
-            # If row8x8 or col8x8 is < 0 just skip the test for now
-            if row8x8 < 0 or col8x8 < 0:
+            # If row8x8 or col8x8 is < -512 just skip the test for now
+            if row8x8 < -512 or col8x8 < -512:
                 continue
 
             dark_ref = full_img_dark.aca[row8x8 : row8x8 + 8, col8x8 : col8x8 + 8]

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -507,11 +507,12 @@ def images_check_range(start, stop, img_table, *, bgsub):
 
     # Check that if the table has BGSUB column that IMG - DARK = BGSUB
     if bgsub:
-        assert np.allclose(img_table["IMG"] - img_table["IMG_DARK"], img_table["IMG_BGSUB"])
+        assert np.allclose(
+            img_table["IMG"] - img_table["IMG_DARK"], img_table["IMG_BGSUB"]
+        )
 
     # If there's a DARK column, then check it against the dark image from the dark cal
     if bgsub:
-
         dc = get_dark_cal_props(
             tstart, select="nearest", include_image=True, aca_image=True
         )

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -532,19 +532,19 @@ def images_check_range(start, stop, img_table):
             assert np.allclose(img_dark, dark_row)
 
 
-def test_get_aca_image_table_maude():
-    """Test get_aca_image_table in the maude mode
+def test_get_aca_images_maude():
+    """Test get_aca_images in the maude mode
 
     This checks that the dark images are reasonable and the IMG data matches with
     and without the bgsub.
     """
     tstart = "2021:001:00:00:00"
     tstop = "2021:001:00:01:00"
-    img_table_maude = chandra_aca.aca_image.get_aca_image_table(
+    img_table_maude = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="maude", bgsub=False
     )
     images_check_range(tstart, tstop, img_table_maude)
-    img_table_maude_bgsub = chandra_aca.aca_image.get_aca_image_table(
+    img_table_maude_bgsub = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="maude", bgsub=True
     )
     images_check_range(tstart, tstop, img_table_maude_bgsub)
@@ -556,28 +556,28 @@ HAS_ACA0_ARCHIVE = (Path(mica.common.MICA_ARCHIVE) / "aca0").exists()
 
 
 @pytest.mark.skipif(not HAS_ACA0_ARCHIVE, reason="No ACA0 archive")
-def test_get_aca_image_table_mica():
-    """Test get_aca_image_table in the mica mode
+def test_get_aca_images_mica():
+    """Test get_aca_images in the mica mode
 
     This checks that the dark images are reasonable and the answers match maude.
     """
     tstart = "2012:180:00:00:00"
     tstop = "2012:180:00:01:00"
 
-    img_table_mica = chandra_aca.aca_image.get_aca_image_table(
+    img_table_mica = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="mica", bgsub=False
     )
     images_check_range(tstart, tstop, img_table_mica)
-    img_table_mica_bgsub = chandra_aca.aca_image.get_aca_image_table(
+    img_table_mica_bgsub = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="mica", bgsub=True
     )
     images_check_range(tstart, tstop, img_table_mica_bgsub)
 
     # Get maude data too for comparison
-    img_table_maude = chandra_aca.aca_image.get_aca_image_table(
+    img_table_maude = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="maude", bgsub=False
     )
-    img_table_maude_bgsub = chandra_aca.aca_image.get_aca_image_table(
+    img_table_maude_bgsub = chandra_aca.aca_image.get_aca_images(
         tstart, tstop, source="maude", bgsub=True
     )
 

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -511,7 +511,6 @@ def images_check_range(start, stop, img_table):
 
     # If there's a DARK column, then check it against the dark image from the dark cal
     if "DARK" in img_table.colnames:
-        from mica.archive.aca_dark import get_dark_cal_props
 
         dc = get_dark_cal_props(
             tstart, select="nearest", include_image=True, aca_image=True

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -535,7 +535,8 @@ def images_check_range(start, stop, img_table):
 def test_get_aca_image_table_maude():
     """Test get_aca_image_table in the maude mode
 
-    This checks that the dark images are reasonable and the IMG data matches with and without the bgsub.
+    This checks that the dark images are reasonable and the IMG data matches with
+    and without the bgsub.
     """
     tstart = "2021:001:00:00:00"
     tstop = "2021:001:00:01:00"

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -556,22 +556,22 @@ HAS_ACA0_ARCHIVE = (Path(mica.common.MICA_ARCHIVE) / "aca0").exists()
 
 
 @pytest.mark.skipif(not HAS_ACA0_ARCHIVE, reason="No ACA0 archive")
-def test_get_aca_images_mica():
-    """Test get_aca_images in the mica mode
+def test_get_aca_images_cxc():
+    """Test get_aca_images in the cxc mode
 
     This checks that the dark images are reasonable and the answers match maude.
     """
     tstart = "2012:180:00:00:00"
     tstop = "2012:180:00:01:00"
 
-    img_table_mica = chandra_aca.aca_image.get_aca_images(
-        tstart, tstop, source="mica", bgsub=False
+    img_table_cxc = chandra_aca.aca_image.get_aca_images(
+        tstart, tstop, source="cxc", bgsub=False
     )
-    images_check_range(tstart, tstop, img_table_mica)
-    img_table_mica_bgsub = chandra_aca.aca_image.get_aca_images(
-        tstart, tstop, source="mica", bgsub=True
+    images_check_range(tstart, tstop, img_table_cxc)
+    img_table_cxc_bgsub = chandra_aca.aca_image.get_aca_images(
+        tstart, tstop, source="cxc", bgsub=True
     )
-    images_check_range(tstart, tstop, img_table_mica_bgsub)
+    images_check_range(tstart, tstop, img_table_cxc_bgsub)
 
     # Get maude data too for comparison
     img_table_maude = chandra_aca.aca_image.get_aca_images(
@@ -582,16 +582,16 @@ def test_get_aca_images_mica():
     )
 
     # Check that the two mica tables are the same in the key columns
-    assert np.allclose(img_table_mica["IMG"], img_table_mica_bgsub["IMG"])
-    assert np.allclose(img_table_mica["TIME"], img_table_mica_bgsub["TIME"])
+    assert np.allclose(img_table_cxc["IMG"], img_table_cxc_bgsub["IMG"])
+    assert np.allclose(img_table_cxc["TIME"], img_table_cxc_bgsub["TIME"])
 
     # Check that the tables are the same
     img_table_maude.sort(["TIME", "IMGNUM"])
     img_table_maude_bgsub.sort(["TIME", "IMGNUM"])
-    img_table_mica.sort(["TIME", "IMGNUM"])
-    img_table_mica_bgsub.sort(["TIME", "IMGNUM"])
+    img_table_cxc.sort(["TIME", "IMGNUM"])
+    img_table_cxc_bgsub.sort(["TIME", "IMGNUM"])
 
-    assert np.allclose(img_table_maude["IMG"], img_table_mica["IMG"])
-    assert np.allclose(img_table_maude["TIME"], img_table_mica["TIME"])
-    assert np.allclose(img_table_maude_bgsub["IMG"], img_table_mica_bgsub["IMG"])
-    assert np.allclose(img_table_maude_bgsub["TIME"], img_table_mica_bgsub["TIME"])
+    assert np.allclose(img_table_maude["IMG"], img_table_cxc["IMG"])
+    assert np.allclose(img_table_maude["TIME"], img_table_cxc["TIME"])
+    assert np.allclose(img_table_maude_bgsub["IMG"], img_table_cxc_bgsub["IMG"])
+    assert np.allclose(img_table_maude_bgsub["TIME"], img_table_cxc_bgsub["TIME"])

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -299,7 +299,7 @@ def test_dcsub_aca_images_maude():
         ]
     )
     np.allclose(exp0, imgs_bgsub[0][0].filled(0), atol=1, rtol=0)
-    np.allclose(exp0, imgs_bgsub_table["BGSUB"][0][0].filled(0), atol=1, rtol=0)
+    np.allclose(exp0, imgs_bgsub_table["IMG_BGSUB"][0][0].filled(0), atol=1, rtol=0)
 
     # slot 4 is 6x6 and masked
     exp4 = np.array(
@@ -315,4 +315,4 @@ def test_dcsub_aca_images_maude():
         ]
     )
     np.allclose(exp4, imgs_bgsub[4][0].filled(0), atol=1, rtol=0)
-    np.allclose(exp4, imgs_bgsub_table["BGSUB"][4][0].filled(0), atol=1, rtol=0)
+    np.allclose(exp4, imgs_bgsub_table["IMG_BGSUB"][4][0].filled(0), atol=1, rtol=0)

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -1,0 +1,295 @@
+from pathlib import Path
+
+import mica.common
+import numpy as np
+import pytest
+from astropy.table import Table
+from mica.archive.aca_dark import get_dark_cal_props
+from numpy import ma
+
+from chandra_aca.dark_subtract import (
+    get_dark_backgrounds,
+    get_dark_current_imgs,
+    get_dcsub_aca_images,
+    get_maude_images,
+    get_mica_images,
+)
+
+HAS_ACA0_ARCHIVE = (Path(mica.common.MICA_ARCHIVE) / "aca0").exists()
+
+
+# Make a test fixture for the mock dark current image
+@pytest.fixture
+def mock_dc():
+    """
+    Make a mock dark current image with some values in the corner.
+    """
+    mock_dc = np.zeros((1024, 1024))
+    # put some ints in the corner
+    for i in range(16):
+        for j in range(16):
+            mock_dc[i, j] = i + j
+    return mock_dc
+
+
+# Make a test fixture for the mock 8x8 data
+@pytest.fixture
+def mock_imgs():
+    """
+    Make a mock 8x8 image table.
+
+    The intent is that these image coordinates should overlap with the mock dark current.
+    """
+    imgs = {}
+    img_table = Table()
+    img_table["TIME"] = np.arange(8)
+    img_table["IMGROW0_8X8"] = ma.arange(8) - 512
+    img_table["IMGCOL0_8X8"] = ma.arange(8) - 512
+    img_table["IMG"] = np.ones((8, 8, 8)) * 16 * 1.696 / 5
+    imgs[0] = img_table
+    return imgs
+
+
+# Test fixture array of dark current images in DN
+@pytest.fixture
+def dc_imgs_dn():
+    """
+    Save expected results of extracted dark current images in this array.
+    """
+    dc_imgs_dn = np.array(
+        [
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+                [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+                [4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+                [6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0],
+                [7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0],
+            ],
+            [
+                [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+                [4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+                [6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0],
+                [7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0],
+                [8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+            ],
+            [
+                [4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+                [6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0],
+                [7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0],
+                [8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+                [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
+            ],
+            [
+                [6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0],
+                [7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0],
+                [8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+                [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
+                [12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0],
+                [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0],
+            ],
+            [
+                [8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+                [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
+                [12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0],
+                [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0],
+                [14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0],
+            ],
+            [
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+                [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
+                [12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0],
+                [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0],
+                [14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0],
+                [16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0],
+                [17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0],
+            ],
+            [
+                [12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0],
+                [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0],
+                [14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0],
+                [16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0],
+                [17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0],
+                [18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0],
+                [19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0],
+            ],
+            [
+                [14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0],
+                [16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0],
+                [17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0],
+                [18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0],
+                [19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0],
+                [20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0],
+                [21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0],
+            ],
+        ]
+    )
+    return dc_imgs_dn
+
+
+def test_dcsub_aca_images(mock_dc, mock_imgs, dc_imgs_dn):
+    """
+    Confirm that the pattern of background subtraction is correct.
+    """
+
+    imgs_bgsub = get_dcsub_aca_images(
+        aca_images=mock_imgs,
+        dc_img=mock_dc,
+        dc_tccd=-10,
+        t_ccd=np.repeat(-10, 8),
+        t_ccd_times=mock_imgs[0]["TIME"],
+    )
+    assert imgs_bgsub[0].shape == (8, 8, 8)
+    # Note that the mock unsubtracted data is originally 16 * 1.696 / 5
+    exp = 16 - dc_imgs_dn
+    assert np.allclose(imgs_bgsub[0] * 5 / 1.696, exp, atol=1e-6, rtol=0)
+
+
+def test_get_dark_images(mock_dc, mock_imgs, dc_imgs_dn):
+    """
+    Confirm the pattern of dark current images matches the reference.
+    The temperature scaling is set here to be a no-op.
+    """
+    dc_imgs = get_dark_current_imgs(
+        mock_imgs[0],
+        dc_img=mock_dc,
+        dc_tccd=-10,
+        t_ccd=np.repeat(-10, 8),
+        t_ccd_times=mock_imgs[0]["TIME"],
+    )
+    assert dc_imgs.shape == (8, 8, 8)
+    dc_imgs_raw = dc_imgs * 5 / 1.696
+    assert np.allclose(dc_imgs_raw, dc_imgs_dn, atol=1e-6, rtol=0)
+
+
+def test_get_dark_backgrounds(mock_dc, mock_imgs, dc_imgs_dn):
+    """
+    Confirm the pattern of dark current matches the reference.
+    """
+    dc_imgs_raw = get_dark_backgrounds(
+        mock_dc,
+        mock_imgs[0]["IMGROW0_8X8"].data.filled(1025),
+        mock_imgs[0]["IMGCOL0_8X8"].data.filled(1025),
+    )
+    assert dc_imgs_raw.shape == (8, 8, 8)
+    assert np.allclose(dc_imgs_raw, dc_imgs_dn, atol=1e-6, rtol=0)
+
+
+@pytest.mark.skipif(not HAS_ACA0_ARCHIVE, reason="No ACA0 archive")
+def test_get_images():
+    """
+    Confirm mica and maude images sources agree for a small time range.
+    """
+    tstart = 746484519.429
+    imgs_maude = get_maude_images(tstart, tstart + 30)
+    imgs_mica = get_mica_images(tstart, tstart + 30)
+    for slot in range(8):
+        assert len(imgs_maude[slot]) == len(imgs_mica[slot])
+        for col in ["IMG", "IMGROW0_8X8", "IMGCOL0_8X8", "TIME"]:
+            assert np.allclose(
+                imgs_maude[slot][col], imgs_mica[slot][col], atol=0.1, rtol=0
+            )
+
+
+def test_dc_consistent():
+    """
+    Confirm extracted dark current is reasonably consistent with the images
+    edges of a 6x6.
+    """
+    tstart = 746484519.429
+    imgs_maude = get_maude_images(tstart, tstart + 30)
+    # This slot and this time show an overall decent correlation of dark current
+    # and edge pixel values in the 6x6 image - but don't make a great test.
+    slot = 4
+    img = imgs_maude[slot]["IMG"][0]
+
+    dc = get_dark_cal_props(tstart, "nearest", include_image=True, aca_image=False)
+    dc_imgs = get_dark_current_imgs(
+        imgs_maude[slot],
+        dc_img=dc["image"],
+        dc_tccd=dc["t_ccd"],
+        t_ccd=np.repeat(-9.9, len(imgs_maude[slot])),
+        t_ccd_times=imgs_maude[slot]["TIME"],
+    )
+    edge_mask_6x6 = np.zeros((8, 8), dtype=bool)
+    edge_mask_6x6[1, 2:6] = True
+    edge_mask_6x6[6, 2:6] = True
+    edge_mask_6x6[2:6, 1] = True
+    edge_mask_6x6[2:6, 6] = True
+
+    # Here just show that a lot of pixels are within 50 e-/s of the dark current
+    # In the 6x6, star spoiling is a large effect.
+    assert (
+        np.percentile(img[edge_mask_6x6].filled(0) - dc_imgs[0][edge_mask_6x6], 50) < 50
+    )
+
+
+def test_dcsub_aca_images_maude():
+    """
+    Test that dark current background subtracted images match
+    references saved in the test.
+    """
+    # This one is just a regression test
+    tstart = 471139130.93277466  # dwell tstart for obsid 15600 - random obsid
+    tstop = tstart + 20
+    imgs_bgsub = get_dcsub_aca_images(tstart, tstop, source="maude")
+
+    exp0 = np.array(
+        [
+            [7, 8, 22, 49, 71, 75, 23, 17],
+            [22, 31, 33, 75, 125, 83, 54, 24],
+            [28, 50, 166, 367, 491, 311, 144, 45],
+            [48, 152, 748, 4124, 5668, 1548, 435, 94],
+            [50, 202, 966, 5895, 8722, 2425, 615, 141],
+            [29, 88, 331, 999, 1581, 631, 382, 103],
+            [16, 36, 108, 279, 302, 229, 112, 62],
+            [14, 14, 33, 69, 71, 49, 33, 25],
+        ]
+    )
+    np.allclose(exp0, imgs_bgsub[0][0].filled(0), atol=1, rtol=0)
+
+    # slot 4 is 6x6 and masked
+    exp4 = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 35, 41, 51, 63, 0, 0],
+            [0, 84, 301, 572, 498, 124, 56, 0],
+            [0, 311, 1982, 4991, 4314, 475, 116, 0],
+            [0, 773, 4551, 3157, 4647, 687, 100, 0],
+            [0, 617, 2586, 3120, 2617, 296, 55, 0],
+            [0, 0, 425, 1372, 344, 70, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    np.allclose(exp4, imgs_bgsub[4][0].filled(0), atol=1, rtol=0)
+
+
+@pytest.mark.skipif(not HAS_ACA0_ARCHIVE, reason="No ACA0 archive")
+def test_dcsub_aca_images_mica_maude():
+    """
+    Confirm background subtracted mica/maude images match for small time range.
+    """
+    tstart = 471139130.93277466  # dwell tstart for obsid 15600 - random obsid
+    tstop = tstart + 30
+    imgs_bgsub = get_dcsub_aca_images(tstart, tstop, source="mica")
+
+    imgs_bgsub_maude = get_dcsub_aca_images(tstart, tstop, source="maude")
+
+    for slot in range(8):
+        assert np.allclose(imgs_bgsub[slot], imgs_bgsub_maude[slot], atol=1e-3, rtol=0)

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -7,6 +7,7 @@ import pytest
 from astropy.table import Table
 from mica.archive.aca_dark import get_dark_cal_props
 from numpy import ma
+from cxotime import CxoTime
 
 from chandra_aca import maude_decom
 from chandra_aca.dark_subtract import (
@@ -165,15 +166,17 @@ def test_dcsub_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
 def test_get_tccd_data():
     start = "2021:001:00:00:00.000"
     stop = "2021:001:00:00:30.000"
-    t_ccd_maude, t_ccd_times_maude = get_tccd_data(start, stop, source="maude")
+    times = CxoTime.linspace(start, stop, 8)
+    t_ccd_maude, t_ccd_times_maude = get_tccd_data(times, source="maude")
+    assert np.all(t_ccd_times_maude == times)
     assert np.isclose(t_ccd_maude[0], -6.55137778)
 
     # Confirm the t_ccd values are the same for maude as default fetch data source
     # but only bother if cxc is in the sources.  Technically this should be a skipif.
     if "cxc" in cheta.fetch.data_source.sources():
-        t_ccd, t_ccd_times = get_tccd_data(start, stop)
+        t_ccd, t_ccd_times = get_tccd_data(times)
         assert np.allclose(t_ccd_maude, t_ccd)
-        assert np.allclose(t_ccd_times_maude, t_ccd_times)
+        assert np.allclose(t_ccd_times_maude.secs, t_ccd_times.secs)
 
 
 def test_get_aca_images(mock_dc, mock_img_table, dc_imgs_dn):

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -1,7 +1,4 @@
-from pathlib import Path
-
 import cheta.fetch
-import mica.common
 import numpy as np
 import pytest
 from astropy.table import Table
@@ -16,8 +13,6 @@ from chandra_aca.dark_subtract import (
     get_dark_current_imgs,
     get_tccd_data,
 )
-
-HAS_ACA0_ARCHIVE = (Path(mica.common.MICA_ARCHIVE) / "aca0").exists()
 
 
 # Make a test fixture for the mock dark current image
@@ -204,6 +199,10 @@ def test_get_dark_images(mock_dc, mock_img_table, dc_imgs_dn):
     assert dc_imgs.shape == (8, 8, 8)
     dc_imgs_raw = dc_imgs * 5 / 1.696
     assert np.allclose(dc_imgs_raw, dc_imgs_dn, atol=1e-6, rtol=0)
+
+
+def test_dark_map_at_edges():
+    pass
 
 
 def test_get_dark_backgrounds(mock_dc, mock_img_table, dc_imgs_dn):

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -6,7 +6,7 @@ from cxotime import CxoTime
 from mica.archive.aca_dark import get_dark_cal_props
 
 from chandra_aca import maude_decom
-from chandra_aca.aca_image import get_aca_image_table
+from chandra_aca.aca_image import get_aca_images
 from chandra_aca.dark_subtract import (
     get_aca_images_bgd_sub,
     get_dark_backgrounds,
@@ -284,7 +284,7 @@ def test_dcsub_aca_images_maude():
         imgs_table, img_dark=img_dark, tccd_dark=tccd_dark, t_ccd_vals=t_ccds
     )
 
-    imgs_bgsub_table = get_aca_image_table(tstart, tstop, source="maude")
+    imgs_bgsub_table = get_aca_images(tstart, tstop, source="maude")
 
     exp0 = np.array(
         [

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -148,13 +148,14 @@ def test_dcsub_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
     Confirm that the pattern of background subtraction is correct.
     """
 
-    imgs_bgsub = _get_dcsub_aca_images(
+    table_bgsub = _get_dcsub_aca_images(
         aca_image_table=mock_img_table,
-        dc_img=mock_dc,
-        dc_tccd=-10,
-        t_ccd=np.repeat(-10, 8),
+        img_dark=mock_dc,
+        tccd_dark=-10,
+        t_ccd_vals=np.repeat(-10, 8),
         t_ccd_times=mock_img_table["TIME"],
     )
+    imgs_bgsub = table_bgsub["IMGBGSUB"]
     assert imgs_bgsub.shape == (8, 8, 8)
     # Note that the mock unsubtracted data is originally 16 * 1.696 / 5
     exp = 16 - dc_imgs_dn
@@ -181,11 +182,10 @@ def test_get_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
     """
     dat = _get_dcsub_aca_images(
         aca_image_table=mock_img_table,
-        dc_img=mock_dc,
-        dc_tccd=-10,
-        t_ccd=np.repeat(-10, 8),
+        img_dark=mock_dc,
+        tccd_dark=-10,
+        t_ccd_vals=np.repeat(-10, 8),
         t_ccd_times=mock_img_table["TIME"],
-        full_table=True,
     )
     for col in ["IMG", "IMGROW0_8X8", "IMGCOL0_8X8", "TIME"]:
         assert col in dat.colnames
@@ -202,9 +202,9 @@ def test_get_dark_images(mock_dc, mock_img_table, dc_imgs_dn):
     """
     dc_imgs = get_dark_current_imgs(
         img_table=mock_img_table,
-        dc_img=mock_dc,
-        dc_tccd=-10,
-        t_ccd=np.repeat(-10, 8),
+        img_dark=mock_dc,
+        tccd_dark=-10,
+        t_ccd_vals=np.repeat(-10, 8),
         t_ccd_times=mock_img_table["TIME"],
     )
     assert dc_imgs.shape == (8, 8, 8)
@@ -241,9 +241,9 @@ def test_dc_consistent():
     dc = get_dark_cal_props(tstart, "nearest", include_image=True, aca_image=False)
     dc_imgs = get_dark_current_imgs(
         img_table_slot,
-        dc_img=dc["image"],
-        dc_tccd=dc["t_ccd"],
-        t_ccd=np.repeat(-9.9, len(img_table_slot)),
+        img_dark=dc["image"],
+        tccd_dark=dc["t_ccd"],
+        t_ccd_vals=np.repeat(-9.9, len(img_table_slot)),
         t_ccd_times=img_table_slot["TIME"],
     )
     edge_mask_6x6 = np.zeros((8, 8), dtype=bool)
@@ -267,7 +267,8 @@ def test_dcsub_aca_images_maude():
     # This one is just a regression test
     tstart = 471139130.93277466  # dwell tstart for obsid 15600 - random obsid
     tstop = tstart + 20
-    imgs_bgsub = _get_dcsub_aca_images(tstart, tstop, source="maude")
+    table_bgsub = _get_dcsub_aca_images(tstart, tstop, source="maude")
+    imgs_bgsub = table_bgsub["IMGBGSUB"]
 
     exp0 = np.array(
         [

--- a/docs/dark_subtract.rst
+++ b/docs/dark_subtract.rst
@@ -1,0 +1,5 @@
+chandra_aca.dark_subtract
+=========================
+
+.. automodule:: chandra_aca.dark_subtract
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,15 @@ Dark model
 
     dark_model.rst
 
+
+Dark background subtraction
+---------------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   dark_subtract.rst
+
 MAUDE Decom
 -----------
 


### PR DESCRIPTION
## Description

Add some convenience routines to get dark-current background subtracted ACA images.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
This depends on https://github.com/sot/mica/pull/301 and https://github.com/sot/mica/pull/311 .

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:chandra_aca jean$ git rev-parse HEAD
6e20ccf80970ac9dad70a01e4008a5381d108d0c
(ska3-flight-latest) flame:chandra_aca jean$ python -c "import mica; print(mica.__version__)"
4.37.1.dev2+g8c56ac2
(ska3-flight-latest) flame:chandra_aca jean$ pytest
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 231 items                                                                                                                                               

chandra_aca/tests/test_aca_image.py ...................                                                                                                     [  8%]
chandra_aca/tests/test_all.py ........................                                                                                                      [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                                                            [ 45%]
chandra_aca/tests/test_dark_model.py ............                                                                                                           [ 50%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                                            [ 53%]
chandra_aca/tests/test_drift.py ..........................                                                                                                  [ 64%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                             [ 75%]
chandra_aca/tests/test_planets.py ...............                                                                                                           [ 82%]
chandra_aca/tests/test_psf.py ...                                                                                                                           [ 83%]
chandra_aca/tests/test_residuals.py ss...                                                                                                                   [ 85%]
chandra_aca/tests/test_star_probs.py .................................                                                                                      [100%]


====================================================== 229 passed, 2 skipped, 2 warnings in 65.07s (0:01:05

```

Independent check of unit tests by @taldcroft :
- [x] Mac
```
(masters) ➜  chandra_aca git:(back-subtract) git rev-parse --short HEAD                                              
37560e5
(masters) ➜  chandra_aca git:(back-subtract) pytest
================================================== test session starts ==================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 230 items                                                                                                     

chandra_aca/tests/test_aca_image.py ..................                                                            [  7%]
chandra_aca/tests/test_all.py ........................                                                            [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                  [ 44%]
chandra_aca/tests/test_dark_model.py ............                                                                 [ 50%]
chandra_aca/tests/test_dark_subtract.py ........                                                                  [ 53%]
chandra_aca/tests/test_drift.py ..........................                                                        [ 64%]
chandra_aca/tests/test_maude_decom.py .........................                                                   [ 75%]
chandra_aca/tests/test_planets.py ...............                                                                 [ 82%]
chandra_aca/tests/test_psf.py ...                                                                                 [ 83%]
chandra_aca/tests/test_residuals.py ss...                                                                         [ 85%]
chandra_aca/tests/test_star_probs.py .................................                                            [100%]

============================================ 228 passed, 2 skipped in 40.30s ============================================
```


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

- [Validation of dark current subtraction from centroi residuals](https://gist.github.com/taldcroft/daeba1bd59520b0e06318faaff35704e). 
