### PR TITLE
Fix END_INTEG_TIME for adjust_time=True

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1192,10 +1192,13 @@ def _get_aca_packets(
 
     table["INTEG"] = table["INTEG"] * 0.016
     table["END_INTEG_TIME"] = table["TIME"] + table["INTEG"]
+    
     if adjust_time:
-        dt = table["INTEG"] / 2 + 1.025
-        table["TIME"] -= dt
-        table["END_INTEG_TIME"] -= dt
+        # See https://github.com/sot/chandra_aca/issues/177. These adjujstments make
+        # TIME correspond to the center of integration and END_INTEG_TIME to the end.
+        # See also https://cxc.harvard.edu/mta/ASPECT/Docs/aca_l0_icd.pdf section D.2.4.
+        table["TIME"] -= table["INTEG"] / 2 + 1.025
+        table["END_INTEG_TIME"] = table["TIME"] + table['INTEG'] / 2
 
     if calibrate:
         if "IMG" in table.colnames:


### PR DESCRIPTION
## Description

See #177 for a description. This just changes the code to make `END_INTEG_TIME` match mica ACA L0 values.

Fixes #177 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
To be added.
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
