### PR TITLE
Use CxoTime.linspace on get_aca_images for > 3hour range

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1230,7 +1230,7 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
     """
     if CxoTime(stop) - CxoTime(start) > 1 * u.day:
         raise ValueError("stop - start cannot be greater than 1 day")
-    maude_fetch_times = CxoTime.linspace(start, stop, step_max=2.5 * u.hour)
+    maude_fetch_times = CxoTime.linspace(start, stop, step_max=3.0 * u.hour)
     packet_stack = [
         get_aca_packets(
             start=maude_fetch_times[i],

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1076,7 +1076,8 @@ def get_aca_packets(
     if (CxoTime(stop) - CxoTime(start)) > MAUDE_SINGLE_FETCH_LIMIT:
         raise ValueError(
             f"Requested {CxoTime(stop) - CxoTime(start)} of telemetry. "
-            f"Maximum allowed is {MAUDE_SINGLE_FETCH_LIMIT} at a time (see MAUDE_SINGLE_FETCH_LIMIT)."
+            f"Maximum allowed is {MAUDE_SINGLE_FETCH_LIMIT} at a time "
+            "(see MAUDE_SINGLE_FETCH_LIMIT)."
         )
 
     stop_pad = 0

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1248,7 +1248,8 @@ def get_aca_images(
     stop = CxoTime(stop)
     if (stop + fetch_pad) - (start - fetch_pad) > MAUDE_FETCH_LIMIT:
         raise ValueError(
-            f"stop - start cannot be greater than {MAUDE_FETCH_LIMIT}. Set module variable MAUDE_FETCH_LIMIT if needed."
+            f"stop - start cannot be greater than {MAUDE_FETCH_LIMIT}. "
+            "Set module variable MAUDE_FETCH_LIMIT if needed."
         )
     if step_max is None:
         step_max = MAUDE_FETCH_STEP_MAX
@@ -1257,12 +1258,12 @@ def get_aca_images(
     )
     packet_stack = [
         get_aca_packets(
-            start=maude_fetch_times[i],
-            stop=maude_fetch_times[i + 1],
+            start=istart,
+            stop=istop,
             level0=True,
             **kwargs,
         )
-        for i in range(len(maude_fetch_times) - 1)
+        for istart, istop in zip(maude_fetch_times[:-1], maude_fetch_times[1:])
     ]
     out = vstack(packet_stack)
     # Trim to just have the requested time range

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -694,8 +694,9 @@ def get_raw_aca_packets(start, stop, maude_result=None, **maude_kwargs):
     {'flags': int, 'packets': [],
     'TIME': np.array([]), 'MNF': np.array([]), 'MJF': np.array([])}
     """
-    date_start, date_stop = DateTime(start), DateTime(
-        stop
+    date_start, date_stop = (
+        DateTime(start),
+        DateTime(stop),
     )  # ensure input is proper date
     stop_pad = 1.5 / 86400  # padding at the end in case of trailing partial ACA packets
 
@@ -1068,8 +1069,9 @@ def get_aca_packets(
         combine = True
         calibrate = True
 
-    date_start, date_stop = DateTime(start), DateTime(
-        stop
+    date_start, date_stop = (
+        DateTime(start),
+        DateTime(stop),
     )  # ensure input is proper date
     if (CxoTime(stop) - CxoTime(start)) > MAUDE_SINGLE_FETCH_LIMIT:
         raise ValueError(
@@ -1222,10 +1224,11 @@ def get_aca_images(
     """
     Fetch ACA image telemetry
 
-    Fetch ACA image telemetry from MAUDE and return it as an astropy Table. With the default settings
-    and no additional kwargs, this calls `get_aca_packets()` in a configuration that uses MAUDE frames,
-    combines image data, and sets the TIME associated with each image to the midpoint of the integration
-    time during which that pixel data was collected (matches CXC L0 times). See `get_aca_packets()`.
+    Fetch ACA image telemetry from MAUDE and return it as an astropy Table. With the default
+    settings and no additional kwargs, this calls `get_aca_packets()` in a configuration that
+    uses MAUDE frames, combines image data, and sets the TIME associated with each image to the
+    midpoint of the integration time during which that pixel data was collected (matches CXC L0
+    times). See `get_aca_packets()`.
 
 
     Parameters
@@ -1235,7 +1238,8 @@ def get_aca_images(
     stop
         timestamp, CxoTimeLike.  stop - start cannot be greater than MAUDE_FETCH_LIMIT
     step_max
-        maximum step size for fetching MAUDE data, u.Quantity, optional. Overrides module var MAUDE_FETCH_STEP_MAX
+        maximum step size for fetching MAUDE data, u.Quantity, optional.
+        Overrides module var MAUDE_FETCH_STEP_MAX
     kwargs
         keyword args passed to get_aca_packets
 
@@ -1263,7 +1267,9 @@ def get_aca_images(
             level0=True,
             **kwargs,
         )
-        for istart, istop in zip(maude_fetch_times[:-1], maude_fetch_times[1:])
+        for istart, istop in zip(
+            maude_fetch_times[:-1], maude_fetch_times[1:], strict=False
+        )
     ]
     out = vstack(packet_stack)
     # Trim to just have the requested time range
@@ -1306,8 +1312,9 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
     dict
     {'blobs': [], 'names': np.array([]), 'types': np.array([])}
     """
-    date_start, date_stop = DateTime(start), DateTime(
-        stop
+    date_start, date_stop = (
+        DateTime(start),
+        DateTime(stop),
     )  # ensure input is proper date
     stop_pad = 1.5 / 86400  # padding at the end in case of trailing partial ACA packets
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -4,6 +4,7 @@ import copy
 import os
 import pickle
 
+import astropy.units as u
 import maude
 import numpy as np
 import pytest
@@ -274,10 +275,34 @@ def test_partial_images():
 
 
 def test_aca_images_chunks_1():
-    """Test that a fetch longer than the maude 3 hour limit works"""
+    """Test that a fetch longer than the single limit does not work
+    if the step limit is larger than the single limit"""
+    single_fetch_limit = maude_decom.MAUDE_SINGLE_FETCH_LIMIT
+    step_max = maude_decom.MAUDE_FETCH_STEP_MAX
+    maude_decom.MAUDE_FETCH_STEP_MAX = 2 * u.min
+    maude_decom.MAUDE_SINGLE_FETCH_LIMIT = 1 * u.min
+    try:
+        with pytest.raises(ValueError, match="Maximum allowed"):
+            maude_decom.get_aca_images("2020:001:00:00:00.000", "2020:001:00:02:00.000")
+    finally:
+        maude_decom.MAUDE_FETCH_STEP_MAX = step_max
+        maude_decom.MAUDE_SINGLE_FETCH_LIMIT = single_fetch_limit
+
+
+def test_aca_images_chunks_2():
+    """Test that a fetch longer than the maude step limit works"""
+    single_fetch_limit = maude_decom.MAUDE_SINGLE_FETCH_LIMIT
+    step_max = maude_decom.MAUDE_FETCH_STEP_MAX
+    maude_decom.MAUDE_FETCH_STEP_MAX = 1 * u.min - 1 * u.s
+    maude_decom.MAUDE_SINGLE_FETCH_LIMIT = 1 * u.min
     start = "2023:001:00:00:01.000"  # times picked close to 4.1 image boundary
-    stop = "2023:001:03:30:01.000"  # times picked close to 4.1 image boundary
-    imgs = maude_decom.get_aca_images(start, stop)
+    stop = "2023:001:00:30:03.000"  # times picked close to 4.1 image boundary
+    try:
+        imgs = maude_decom.get_aca_images(start, stop)
+    finally:
+        maude_decom.MAUDE_FETCH_STEP_MAX = step_max
+        maude_decom.MAUDE_SINGLE_FETCH_LIMIT = single_fetch_limit
+
     imgs.sort(["TIME", "IMGNUM"])
 
     for slot in range(8):
@@ -288,20 +313,30 @@ def test_aca_images_chunks_1():
         # Confirm for these 8x8 data that there's no gap > 5 seconds
         assert np.max(np.diff(imgs[ok_slot]["TIME"])) < 5
 
+    # Confirm that the returned data times are within the start stop
+    assert imgs["TIME"][0] >= CxoTime(start).secs
+    assert imgs["TIME"][-1] <= CxoTime(stop).secs
+
+    # Confirm that the beginning and end match the expected values
     assert abs(imgs[0]["TIME"] - CxoTime(start).secs) < 2
     assert abs(imgs[-1]["TIME"] - CxoTime(stop).secs) < 2
-    # Confirm that the beginning and end match the expected values
+
     imgs_start = maude_decom.get_aca_images(start, CxoTime(start).secs + 60)
     imgs_stop = maude_decom.get_aca_images(CxoTime(stop).secs - 60, stop)
     assert np.all(imgs[0] == imgs_start[0])
     assert np.all(imgs[-1] == imgs_stop[-1])
 
+    # Check the linspace times in the returned data
+    used_step_max = 1 * u.min - 1 * u.s
+    deltas_lte = [t <= used_step_max for t in np.diff(imgs.meta["times"])]
+    assert np.all(deltas_lte)
 
-def test_aca_images_chunks_2():
-    """Test that a fetch longer than 1 day throws a ValueError"""
-    start = "2023:001:00:00:00.000"
-    stop = "2023:003:00:00:00.000"
-    with pytest.raises(ValueError, match="stop - start cannot be greater than 1 day"):
+
+def test_aca_images_chunks_3():
+    """Test that a fetch longer than MAUDE_FETCH_LIMIT throws a ValueError"""
+    start = CxoTime("2023:001:00:00:01.000")
+    stop = start + (maude_decom.MAUDE_FETCH_LIMIT * 1.1)
+    with pytest.raises(ValueError, match="stop - start cannot be greater than"):
         maude_decom.get_aca_images(start, stop)
 
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -297,6 +297,8 @@ def test_aca_images_chunks_2():
     maude_decom.MAUDE_SINGLE_FETCH_LIMIT = 1 * u.min
     start = "2023:001:00:00:01.000"  # times picked close to 4.1 image boundary
     stop = "2023:001:00:30:03.000"  # times picked close to 4.1 image boundary
+    tstart = CxoTime(start).secs
+    tstop = CxoTime(stop).secs
     try:
         imgs = maude_decom.get_aca_images(start, stop)
     finally:
@@ -314,15 +316,15 @@ def test_aca_images_chunks_2():
         assert np.max(np.diff(imgs[ok_slot]["TIME"])) < 5
 
     # Confirm that the returned data times are within the start stop
-    assert imgs["TIME"][0] >= CxoTime(start).secs
-    assert imgs["TIME"][-1] <= CxoTime(stop).secs
+    assert imgs["TIME"][0] >= tstart
+    assert imgs["TIME"][-1] <= tstop
 
     # Confirm that the beginning and end match the expected values
-    assert abs(imgs[0]["TIME"] - CxoTime(start).secs) < 2
-    assert abs(imgs[-1]["TIME"] - CxoTime(stop).secs) < 2
+    assert abs(imgs[0]["TIME"] - tstart) < 2
+    assert abs(imgs[-1]["TIME"] - tstop) < 2
 
-    imgs_start = maude_decom.get_aca_images(start, CxoTime(start).secs + 60)
-    imgs_stop = maude_decom.get_aca_images(CxoTime(stop).secs - 60, stop)
+    imgs_start = maude_decom.get_aca_images(start, CxoTime(start) + 60 * u.s)
+    imgs_stop = maude_decom.get_aca_images(CxoTime(stop) - 60 * u.s, stop)
     assert np.all(imgs[0] == imgs_start[0])
     assert np.all(imgs[-1] == imgs_stop[-1])
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -307,6 +307,8 @@ def test_aca_images_chunks_1():
 
     imgs_start = maude_decom.get_aca_images(start, CxoTime(start) + 60 * u.s)
     imgs_stop = maude_decom.get_aca_images(CxoTime(stop) - 60 * u.s, stop)
+    imgs_start.sort(["TIME", "IMGNUM"])
+    imgs_stop.sort(["TIME", "IMGNUM"])
     assert np.all(imgs[0] == imgs_start[0])
     assert np.all(imgs[-1] == imgs_stop[-1])
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -275,34 +275,16 @@ def test_partial_images():
 
 
 def test_aca_images_chunks_1():
-    """Test that a fetch longer than the single limit does not work
-    if the step limit is larger than the single limit"""
-    single_fetch_limit = maude_decom.MAUDE_SINGLE_FETCH_LIMIT
-    step_max = maude_decom.MAUDE_FETCH_STEP_MAX
-    maude_decom.MAUDE_FETCH_STEP_MAX = 2 * u.min
-    maude_decom.MAUDE_SINGLE_FETCH_LIMIT = 1 * u.min
-    try:
-        with pytest.raises(ValueError, match="Maximum allowed"):
-            maude_decom.get_aca_images("2020:001:00:00:00.000", "2020:001:00:02:00.000")
-    finally:
-        maude_decom.MAUDE_FETCH_STEP_MAX = step_max
-        maude_decom.MAUDE_SINGLE_FETCH_LIMIT = single_fetch_limit
-
-
-def test_aca_images_chunks_2():
     """Test that a fetch longer than the maude step limit works"""
     single_fetch_limit = maude_decom.MAUDE_SINGLE_FETCH_LIMIT
-    step_max = maude_decom.MAUDE_FETCH_STEP_MAX
-    maude_decom.MAUDE_FETCH_STEP_MAX = 1 * u.min - 1 * u.s
     maude_decom.MAUDE_SINGLE_FETCH_LIMIT = 1 * u.min
-    start = "2023:001:00:00:01.000"  # times picked close to 4.1 image boundary
-    stop = "2023:001:00:30:03.000"  # times picked close to 4.1 image boundary
+    start = "2023:001:00:00:01.000"
+    stop = "2023:001:00:05:01.000"
     tstart = CxoTime(start).secs
     tstop = CxoTime(stop).secs
     try:
         imgs = maude_decom.get_aca_images(start, stop)
     finally:
-        maude_decom.MAUDE_FETCH_STEP_MAX = step_max
         maude_decom.MAUDE_SINGLE_FETCH_LIMIT = single_fetch_limit
 
     imgs.sort(["TIME", "IMGNUM"])
@@ -334,7 +316,7 @@ def test_aca_images_chunks_2():
     assert np.all(deltas_lte)
 
 
-def test_aca_images_chunks_3():
+def test_aca_images_chunks_2():
     """Test that a fetch longer than MAUDE_FETCH_LIMIT throws a ValueError"""
     start = CxoTime("2023:001:00:00:01.000")
     stop = start + (maude_decom.MAUDE_FETCH_LIMIT * 1.1)


### PR DESCRIPTION
## Description

Use CxoTime.linspace on get_aca_images for > 3hour range

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This is a possible and trivial implementation of @taldcroft 's thought at https://github.com/sot/chandra_aca/pull/174#issuecomment-2363997248 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This allows stop - start > 3 hours for the get_aca_images method.

## Testing
<!-- If relevant describe any special setup for testing. -->
This requires cxotime https://github.com/sot/cxotime/pull/44

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:chandra_aca jean$ git rev-parse HEAD
3bcd3afc612953f4d6c4ac4e1206afecc032f8b5
(ska3-flight-latest) flame:chandra_aca jean$ pytest
============================================================ test session starts =============================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 216 items                                                                                                                          

chandra_aca/tests/test_aca_image.py .................                                                                                  [  7%]
chandra_aca/tests/test_all.py ........................                                                                                 [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                                       [ 47%]
chandra_aca/tests/test_dark_model.py ............                                                                                      [ 52%]
chandra_aca/tests/test_drift.py ..........................                                                                             [ 64%]
chandra_aca/tests/test_maude_decom.py ....................                                                                             [ 74%]
chandra_aca/tests/test_planets.py ...............                                                                                      [ 81%]
chandra_aca/tests/test_psf.py ...                                                                                                      [ 82%]
chandra_aca/tests/test_residuals.py ss...                                                                                              [ 84%]
chandra_aca/tests/test_star_probs.py .................................                                                                 [100%]

============================================================== warnings summary ==============================================================
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 214 passed, 2 skipped, 2 warnings in 77.88s (0:01:17
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
Needs more functional testing.
