### PR TITLE
`get_aca_images()` returns MaskedColumns only for data with masked values (except IMG)

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1426,7 +1426,9 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
     out = vstack(packet_stack)
     out.meta["times"] = maude_fetch_times
 
-    # Remove mask from columns where no values are masked.
+    # Remove mask from columns where no values are masked. IMG is excepted because
+    # the mask reflects the presence of 4x4 or 6x6 images, not entirely missing data
+    # per row.
     for col in out.itercols():
         if not np.any(col.mask) and col.name != "IMG":
             out[col.name] = col.data.data

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -945,7 +945,7 @@ def _aca_packets_to_table(aca_packets, dtype=None):
             if name in aca_packet:
                 array[name][i] = aca_packet[name]
 
-    table = Table(array, masked=True)
+    table = Table(array)
     if img:
         table["IMG"] = img
         for i, aca_packet in enumerate(aca_packets):
@@ -1358,6 +1358,12 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
     ]
     out = vstack(packet_stack)
     out.meta["times"] = maude_fetch_times
+
+    # Remove mask from columns where no values are masked.
+    for col in out.itercols():
+        if not np.any(col.mask):
+            out[col.name] = col.data.data
+
     return out
 
 

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1404,6 +1404,9 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
     -------
     astropy.table.Table
     """
+    # This is strictly for testing, hence undocumented.
+    set_times_metadata = kwargs.pop("set_times_metadata", False)
+
     start = CxoTime(start)
     stop = CxoTime(stop)
     if (stop - start) > MAUDE_FETCH_LIMIT:
@@ -1424,7 +1427,8 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
         for istart, istop in itertools.pairwise(maude_fetch_times)
     ]
     out = vstack(packet_stack)
-    out.meta["times"] = maude_fetch_times
+    if set_times_metadata:
+        out.meta["times"] = maude_fetch_times
 
     # Remove mask from columns where no values are masked. IMG is excepted because
     # the mask reflects the presence of 4x4 or 6x6 images, not entirely missing data

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1361,7 +1361,7 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
 
     # Remove mask from columns where no values are masked.
     for col in out.itercols():
-        if not np.any(col.mask):
+        if not np.any(col.mask) and col.name != "IMG":
             out[col.name] = col.data.data
 
     return out

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -1287,3 +1287,38 @@ def test_end_integ_time(combine):
             rtol=0,
         )
     )
+
+
+def test_get_aca_image_masked_columns_1():
+    """Get images over a time covering end of maneuver and start of dwell
+
+    This has fids (8x8), guides (6x6) and null images (4x4).
+    """
+    start = "2018:024:23:05:00"
+    stop = "2018:024:23:10:00"
+    imgs = maude_decom.get_aca_images(start, stop)
+    # 4x4, 6x6, and 8x8 images
+    assert set(imgs["IMGTYPE"]) == {0, 1, 4}
+    # Null, tracking, and search
+    assert set(imgs["IMGFUNC"]) == {0, 1, 3}
+    cols_masked = {col.info.name for col in imgs.itercols() if hasattr(col, "mask")}
+    assert cols_masked == {'BGDRMS', 'TEMPCCD', 'TEMPHOUS', 'TEMPPRIM', 'TEMPSEC', 'BGDSTAT', 'IMG'}
+
+
+def test_get_aca_image_masked_columns_2():
+    """Only 6x6 and 8x8 so only IMG is masked"""
+    start = "2018:024:23:15:00"
+    stop = "2018:024:23:20:00"
+    imgs = maude_decom.get_aca_images(start, stop)
+    assert set(imgs["IMGTYPE"]) == {1, 4}
+    cols_masked = {col.info.name for col in imgs.itercols() if hasattr(col, "mask")}
+    assert cols_masked == {"IMG"}
+
+def test_get_aca_image_masked_columns_3():
+    """Only 8x8 so only IMG masked"""
+    start = "2024:001:00:00:00"
+    stop = "2024:001:00:01:00"
+    imgs = maude_decom.get_aca_images(start, stop)
+    assert set(imgs["IMGTYPE"]) == {4}
+    cols_masked = {col.info.name for col in imgs.itercols() if hasattr(col, "mask")}
+    assert cols_masked == {"IMG"}

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -283,7 +283,8 @@ def test_aca_images_chunks_1():
     tstart = CxoTime(start).secs
     tstop = CxoTime(stop).secs
     try:
-        imgs = maude_decom.get_aca_images(start, stop)
+        # Include the "times" metadata in the returned images table for testing
+        imgs = maude_decom.get_aca_images(start, stop, set_times_metadata=True)
     finally:
         maude_decom.MAUDE_SINGLE_FETCH_LIMIT = single_fetch_limit
 

--- a/chandra_aca/tests/test_maude_decom.py
+++ b/chandra_aca/tests/test_maude_decom.py
@@ -1303,7 +1303,15 @@ def test_get_aca_image_masked_columns_1():
     # Null, tracking, and search
     assert set(imgs["IMGFUNC"]) == {0, 1, 3}
     cols_masked = {col.info.name for col in imgs.itercols() if hasattr(col, "mask")}
-    assert cols_masked == {'BGDRMS', 'TEMPCCD', 'TEMPHOUS', 'TEMPPRIM', 'TEMPSEC', 'BGDSTAT', 'IMG'}
+    assert cols_masked == {
+        "BGDRMS",
+        "TEMPCCD",
+        "TEMPHOUS",
+        "TEMPPRIM",
+        "TEMPSEC",
+        "BGDSTAT",
+        "IMG",
+    }
 
 
 def test_get_aca_image_masked_columns_2():
@@ -1314,6 +1322,7 @@ def test_get_aca_image_masked_columns_2():
     assert set(imgs["IMGTYPE"]) == {1, 4}
     cols_masked = {col.info.name for col in imgs.itercols() if hasattr(col, "mask")}
     assert cols_masked == {"IMG"}
+
 
 def test_get_aca_image_masked_columns_3():
     """Only 8x8 so only IMG masked"""


### PR DESCRIPTION
## Description

Change `get_aca_images()` so that it converts the `MaskedColumn` columns from `get_aca_packets` to `Column` if there are no masked elements. 

The only columns that can actually be missing are: 'BGDRMS', 'TEMPCCD', 'TEMPHOUS', 'TEMPPRIM', 'TEMPSEC', 'BGDSTAT'. These columns are not present in 4x4 images, so any query that includes 4x4 images will have these masked.

The 'IMG' column is still always masked because the mask has a slightly different meaning, namely providing the data mask for 4x4 and 6x6 images.

### Unrelated fix
Functional testing with kalman_watch showed a problem with #181, namely that merging (`vstack`) of image tables with a `times` metadata caused warnings:
```
WARNING: Attribute `times` of type <class 'cxotime.cxotime.CxoTime'> cannot be added to FITS Header - skipping [astropy.io.fits.convenience]
WARNING: MergeConflictWarning: Cannot merge meta key 'times' types <class 'cxotime.cxotime.CxoTime'> and <class 'cxotime.cxotime.CxoTime'>, choosing times=<CxoTime object: scale='utc' format='date' value=['2024:308:01:44:40.211' '2024:308:02:19:13.786']> [astropy.utils.metadata.merge]
```
So this PR changes that `times` meta attribute to be opt-in for testing via an undocumented keyword arg `set_times_metadata`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Column types are changed. 

- `aca_view` does not call `get_aca_images()`.
- The only other production code calling `get_aca_images()` is `kalman_watch`, so this is functionally tested.

## Requires
Requires `masters` environment (at least `CxoTime.linspace()`).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new tests)
```
(masters) ➜  chandra_aca git:(mask-only-masked-data) git rev-parse --short HEAD                                 
d65fc41
(masters) ➜  chandra_aca git:(mask-only-masked-data) pytest
============================================== test session starts ===============================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 221 items                                                                                              

chandra_aca/tests/test_aca_image.py .................                                                      [  7%]
chandra_aca/tests/test_all.py ........................                                                     [ 18%]
chandra_aca/tests/test_attitude.py .............................................................           [ 46%]
chandra_aca/tests/test_dark_model.py ............                                                          [ 51%]
chandra_aca/tests/test_drift.py ..........................                                                 [ 63%]
chandra_aca/tests/test_maude_decom.py .........................                                            [ 74%]
chandra_aca/tests/test_planets.py ...............                                                          [ 81%]
chandra_aca/tests/test_psf.py ...                                                                          [ 82%]
chandra_aca/tests/test_residuals.py ss...                                                                  [ 85%]
chandra_aca/tests/test_star_probs.py .................................                                     [100%]

======================================== 219 passed, 2 skipped in 45.03s =========================================

```
Independent check of unit tests by Jean
- [x] Linux
```
(ska3-masters) jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 221 items                                                            

chandra_aca/tests/test_aca_image.py .................                    [  7%]
chandra_aca/tests/test_all.py ........................                   [ 18%]
chandra_aca/tests/test_attitude.py ..................................... [ 35%]
........................                                                 [ 46%]
chandra_aca/tests/test_dark_model.py ............                        [ 51%]
chandra_aca/tests/test_drift.py ..........................               [ 63%]
chandra_aca/tests/test_maude_decom.py .........................          [ 74%]
chandra_aca/tests/test_planets.py ...............                        [ 81%]
chandra_aca/tests/test_psf.py ...                                        [ 82%]
chandra_aca/tests/test_residuals.py .....                                [ 85%]
chandra_aca/tests/test_star_probs.py .................................   [100%]

======================== 221 passed in 95.37s (0:01:35) ========================
(ska3-masters) jeanconn-fido> git rev-parse HEAD
d372a2766f39565a639dbe079e91f7f2016755d6
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran `kalman_watch` task_schedule tasks on Mac in `masters` environment with this PR in the PYTHONPATH.
No errors or warnings were produced and the outputs look reasonable:
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/chandra_aca/pr-182/kw3/
