### PR TITLE
Migrate maude_decom to CxoTime

### DIFF
--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -82,7 +82,6 @@ import astropy.units as u
 import maude
 import numpy as np
 from astropy.table import Table, vstack
-from Chandra.Time import DateTime
 from cxotime import CxoTime, CxoTimeLike
 
 # Maude fetch limits
@@ -678,13 +677,13 @@ def get_raw_aca_packets(start, stop, maude_result=None, **maude_kwargs):
 
     Parameters
     ----------
-    start
-        timestamp interpreted as a Chandra.Time.DateTime
-    stop
-        timestamp interpreted as a Chandra.Time.DateTime
+    start : CxoTimeLike
+        Start time for packets
+    stop : CxoTimeLike
+        Stop time for packets
     maude_result
         the result of calling maude.get_frames. Optional.
-    maude_kwargs
+    **maude_kwargs
         keyword args passed to maude.get_frames()
 
     Returns
@@ -693,11 +692,8 @@ def get_raw_aca_packets(start, stop, maude_result=None, **maude_kwargs):
     {'flags': int, 'packets': [],
     'TIME': np.array([]), 'MNF': np.array([]), 'MJF': np.array([])}
     """
-    date_start, date_stop = (
-        DateTime(start),
-        DateTime(stop),
-    )  # ensure input is proper date
-    stop_pad = 1.5 / 86400  # padding at the end in case of trailing partial ACA packets
+    date_start, date_stop = CxoTime(start), CxoTime(stop)
+    stop_pad = 1.5 * u.s  # padding at the end in case of trailing partial ACA packets
 
     # get the frames and unpack front matter
     if maude_result is None:
@@ -1024,10 +1020,10 @@ def get_aca_packets(
 
     Parameters
     ----------
-    start
-        timestamp interpreted as a Chandra.Time.DateTime
-    stop
-        timestamp interpreted as a Chandra.Time.DateTime
+    start : CxoTimeLike
+        Start time for the ACA packets
+    stop : CxoTimeLike
+        Stop time for the ACA packets
     level0 : bool.
         Implies combine=True, adjust_time=True, calibrate=True
     combine : bool.
@@ -1049,8 +1045,8 @@ def get_aca_packets(
         including MSIDs that are present in blobs. If used with frames, most probably you will get
         and empty column. This option is intended to augment the default dtype. If a more
         restrictive dtype is used, a KeyError can be raised.
-    maude_kwargs
-        keyword args passed to maude
+    **maude_kwargs
+        Keyword args passed to maude
 
     Returns
     -------
@@ -1068,29 +1064,24 @@ def get_aca_packets(
         combine = True
         calibrate = True
 
-    date_start, date_stop = (
-        DateTime(start),
-        DateTime(stop),
-    )  # ensure input is proper date
-    if (CxoTime(stop) - CxoTime(start)) > MAUDE_SINGLE_FETCH_LIMIT:
+    date_start, date_stop = CxoTime(start), CxoTime(stop)
+    if date_stop - date_start > MAUDE_SINGLE_FETCH_LIMIT:
         raise ValueError(
-            f"Requested {CxoTime(stop) - CxoTime(start)} of telemetry. "
+            f"Requested {(date_stop - date_start).to_value('hr')} hr of telemetry. "
             f"Maximum allowed is {MAUDE_SINGLE_FETCH_LIMIT} at a time "
             "(see MAUDE_SINGLE_FETCH_LIMIT)."
         )
 
-    stop_pad = 0
+    stop_pad = 0 * u.s
     if adjust_time:
-        stop_pad += 2.0 / 86400  # time will get shifted...
+        stop_pad += 2.0 * u.s  # time will get shifted...
     if combine:
-        stop_pad += 3.08 / 86400  # there can be trailing frames
+        stop_pad += 3.08 * u.s  # there can be trailing frames
 
     if frames:
-        n = int(np.ceil(86400 * (date_stop - date_start) / 300))
+        n = int(np.ceil((date_stop - date_start).sec / 300))
         dt = (date_stop - date_start) / n
-        batches = [
-            (date_start + i * dt, date_start + (i + 1) * dt) for i in range(n)
-        ]  # 0.0001????
+        batches = [(date_start + i * dt, date_start + (i + 1) * dt) for i in range(n)]
         aca_packets = []
         for t1, t2 in batches:
             maude_result = (
@@ -1148,7 +1139,7 @@ def _get_aca_packets(
 
     NOTE: This function has a side effect. It adds decom_packets to the input aca_packets.
     """
-    start, stop = DateTime(start), DateTime(stop)  # ensure input is proper date
+    start, stop = CxoTime(start), CxoTime(stop)  # ensure input is proper date
 
     if not blobs:
         # this adds TIME, MJF, MNF and VCDUCTR, which is already there in the blob dictionary
@@ -1228,6 +1219,10 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
     midpoint of the integration time during which that pixel data was collected (matches CXC L0
     times). See `get_aca_packets()`.
 
+    This function can be used to fetch up to 5 days of ACA image telemetry at a time.
+    If more is needed, you can set the module variable ``MAUDE_FETCH_LIMIT`` to a larger
+    value. Internally, this function will fetch the data in intervals of
+    ``MAUDE_SINGLE_FETCH_LIMIT``.
 
     Parameters
     ----------
@@ -1280,7 +1275,7 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
     If the first minor frame in a group of four ACA packets is within (start, stop),
     the three following minor frames are included if present.
 
-    returns a dictionary with keys ['TIME', 'MNF', 'MJF', 'packets', 'flags'].
+    Returns a dictionary with keys ['TIME', 'MNF', 'MJF', 'packets', 'flags'].
     These correspond to the minor frame time, minor frame count, major frame count,
     the list of packets, and flags returned by MAUDE respectively.
 
@@ -1288,13 +1283,13 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
 
     Parameters
     ----------
-    start
-        timestamp interpreted as a Chandra.Time.DateTime
-    stop
-        timestamp interpreted as a Chandra.Time.DateTime
+    start : CxoTimeLike
+        Start time for the ACA blobs
+    stop : CxoTimeLike
+        Stop time for the ACA blobs
     maude_result
         the result of calling maude.get_blobs. Optional.
-    maude_kwargs
+    **maude_kwargs
         keyword args passed to maude.get_frames()
 
     Returns
@@ -1302,11 +1297,9 @@ def get_raw_aca_blobs(start, stop, maude_result=None, **maude_kwargs):
     dict
     {'blobs': [], 'names': np.array([]), 'types': np.array([])}
     """
-    date_start, date_stop = (
-        DateTime(start),
-        DateTime(stop),
-    )  # ensure input is proper date
-    stop_pad = 1.5 / 86400  # padding at the end in case of trailing partial ACA packets
+    date_start, date_stop = CxoTime(start), CxoTime(stop)
+
+    stop_pad = 1.5 * u.s  # padding at the end in case of trailing partial ACA packets
 
     if maude_result is None:
         maude_blobs = maude.get_blobs(


### PR DESCRIPTION
## Description

Migrate `maude_decom.py` to use CxoTime throughout and use recommended idioms for time delta arithmetic.

This also makes some improvements in docstrings. It accidentally includes an update that was intended for #181.

## Requires

- `cxotime` with `CxoTime.linspace()`
- Based off the `maude-aca-chunks` branch.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  docs git:(maude-use-cxotime) git rev-parse HEAD                                                               
374506ed1b5d85e48b5b16d701affbd30ffdbe0b
(ska3) ➜  docs git:(maude-use-cxotime) env PYTHONPATH=/Users/aldcroft/git/cxotime pytest
========================================================= test session starts ==========================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: cov-5.0.0, timeout-2.2.0, anyio-4.3.0
collected 0 items                                                                                                                      

======================================================== no tests ran in 0.03s =========================================================
(ska3) ➜  docs git:(maude-use-cxotime) cd ..
(ska3) ➜  chandra_aca git:(maude-use-cxotime) env PYTHONPATH=/Users/aldcroft/git/cxotime pytest
========================================================= test session starts ==========================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: cov-5.0.0, timeout-2.2.0, anyio-4.3.0
collected 216 items                                                                                                                    

chandra_aca/tests/test_aca_image.py .................                                                                            [  7%]
chandra_aca/tests/test_all.py ........................                                                                           [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                                 [ 47%]
chandra_aca/tests/test_dark_model.py ............                                                                                [ 52%]
chandra_aca/tests/test_drift.py ..........................                                                                       [ 64%]
chandra_aca/tests/test_maude_decom.py ....................                                                                       [ 74%]
chandra_aca/tests/test_planets.py ...............                                                                                [ 81%]
chandra_aca/tests/test_psf.py ...                                                                                                [ 82%]
chandra_aca/tests/test_residuals.py ss...                                                                                        [ 84%]
chandra_aca/tests/test_star_probs.py .................................                                                           [100%]

============================================== 214 passed, 2 skipped, 1 warning in 34.40s ==============================================
```

Independent check of unit tests by Jean
- [x] OSX arm64
```
(ska3-flight-latest) flame:chandra_aca jean$ pytest
============================= test session starts ==============================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 216 items                                                            

chandra_aca/tests/test_aca_image.py .................                    [  7%]
chandra_aca/tests/test_all.py ........................                   [ 18%]
chandra_aca/tests/test_attitude.py ..................................... [ 36%]
........................                                                 [ 47%]
chandra_aca/tests/test_dark_model.py ............                        [ 52%]
chandra_aca/tests/test_drift.py ..........................               [ 64%]
chandra_aca/tests/test_maude_decom.py ....................                                                     [ 74%]
chandra_aca/tests/test_planets.py ...............                                                              [ 81%]
chandra_aca/tests/test_psf.py ...                                                                              [ 82%]
chandra_aca/tests/test_residuals.py ss...                                                                      [ 84%]
chandra_aca/tests/test_star_probs.py .................................                                         [100%]

================================================== warnings summary ==================================================
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 214 passed, 2 skipped, 2 warnings in 44.06
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
