### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/chandra_aca/tests/test_planets.py
+++ b/chandra_aca/tests/test_planets.py
@@ -150,7 +150,7 @@ def test_get_chandra_planet_horizons(body):
         "         5.408    31.76",
     ]
 
-    assert dat.pformat_all() == exp
+    assert dat.pformat() == exp
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
@@ -166,7 +166,7 @@ def test_get_chandra_planet_horizons_non_planet():
         "275.29375 -23.83915     349.43     659.97  --            --       --",
     ]
     del dat["time"]
-    assert dat.pformat_all() == exp
+    assert dat.pformat() == exp
 
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
@@ -235,4 +235,4 @@ def test_earth_boresight():
     ]
 
     blocks = get_earth_blocks(start, stop, min_limb_angle=10.0)
-    assert blocks["datestart", "datestop", "duration"].pformat_all() == exp
+    assert blocks["datestart", "datestop", "duration"].pformat() == exp


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc5) ~/SAO/git/chandra_aca pformat $ pytest chandra_aca
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 230 items                                                                                                                           

chandra_aca/tests/test_aca_image.py ..................                                                                                  [  7%]
chandra_aca/tests/test_all.py ........................                                                                                  [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                                        [ 44%]
chandra_aca/tests/test_dark_model.py ............                                                                                       [ 50%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                        [ 53%]
chandra_aca/tests/test_drift.py ..........................                                                                              [ 64%]
chandra_aca/tests/test_maude_decom.py .........................                                                                         [ 75%]
chandra_aca/tests/test_planets.py ...............                                                                                       [ 82%]
chandra_aca/tests/test_psf.py ...                                                                                                       [ 83%]
chandra_aca/tests/test_residuals.py ss...                                                                                               [ 85%]
chandra_aca/tests/test_star_probs.py .................................                                                                  [100%]

============================================================== warnings summary ===============================================================
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/javierg/miniforge3/envs/ska3-flight-2025.0rc5/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 228 passed, 2 skipped, 2 warnings in 48.26s =================================================
(ska3-flight-2025.0rc5) ~/SAO/git/chandra_aca pformat $ git rev-parse --short HEAD
3776240

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
