### PR TITLE
Change the get_aca_images default to bgsub=False

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -847,7 +847,7 @@ class AcaPsfLibrary(object):
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_aca_images(
-    start: CxoTimeLike, stop: CxoTimeLike, bgsub=True, source="maude", **maude_kwargs
+    start: CxoTimeLike, stop: CxoTimeLike, bgsub=False, source="maude", **maude_kwargs
 ) -> Table:
     """
     Get ACA images and ancillary data from either the MAUDE or CXC data sources.
@@ -880,7 +880,7 @@ def get_aca_images(
     stop : CxoTimeLike
         Stop time (CXC sec).
     bgsub : bool
-        Include background subtracted images in output table.
+        Include background subtracted images in output table. Default is False.
     source : str
         Data source for image and temperature telemetry ('maude' or 'cxc'). For 'cxc',
         the image telemetry is from mica and temperature telemetry is from CXC L0 via

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -284,7 +284,7 @@ def test_dcsub_aca_images_maude():
         imgs_table, img_dark=img_dark, tccd_dark=tccd_dark, t_ccd_vals=t_ccds
     )
 
-    imgs_bgsub_table = get_aca_images(tstart, tstop, source="maude")
+    imgs_bgsub_table = get_aca_images(tstart, tstop, source="maude", bgsub=True)
 
     exp0 = np.array(
         [


### PR DESCRIPTION
## Description
Change the get_aca_images default to bgsub=False

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested in a recent 2025.0 test env.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(2025.0) flame:chandra_aca jean$ git rev-parse HEAD
5181dde2a01fceeb1396402b124576fcf7245c13
(2025.0) flame:chandra_aca jean$ pytest
========================================================== test session starts ==========================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 230 items                                                                                                                     

chandra_aca/tests/test_aca_image.py ..................                                                                            [  7%]
chandra_aca/tests/test_all.py ........................                                                                            [ 18%]
chandra_aca/tests/test_attitude.py .............................................................                                  [ 44%]
chandra_aca/tests/test_dark_model.py ............                                                                                 [ 50%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                  [ 53%]
chandra_aca/tests/test_drift.py ..........................                                                                        [ 64%]
chandra_aca/tests/test_maude_decom.py .........................                                                                   [ 75%]
chandra_aca/tests/test_planets.py ...............                                                                                 [ 82%]
chandra_aca/tests/test_psf.py ...                                                                                                 [ 83%]
chandra_aca/tests/test_residuals.py ss...                                                                                         [ 85%]
chandra_aca/tests/test_star_probs.py .................................                                                            [100%]

=========================================================== warnings summary
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
