### PR TITLE
Add drift_pars kwarg to get_aca_offsets and get_fid_offset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.0
+  rev: v0.9.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/chandra_aca/tests/test_drift.py
+++ b/chandra_aca/tests/test_drift.py
@@ -4,9 +4,13 @@ from pathlib import Path
 import astropy.table as tbl
 import numpy as np
 import pytest
+from ska_helpers.utils import LazyDict
 
 from chandra_aca import drift
 
+# Drift pars for testing that may reflect a new model in a non-flight testing repo.
+# See test_get_aca_offsets() for how to test a new drift model.
+DRIFT_PARS_TEST = LazyDict(drift.load_drift_pars)
 
 def test_get_aca_offsets_legacy():
     """
@@ -53,13 +57,38 @@ for row in dat:
 
 
 @pytest.mark.parametrize("kwargs", kwargs_list)
-def test_get_aca_offsets(kwargs, monkeypatch):
-    """Regression test that ACA offsets match the original flight values from 2022-11
-    analysis to expected precision."""
-    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+@pytest.mark.parametrize("use_drift_pars", [True, False])
+def test_get_aca_offsets(kwargs, use_drift_pars):
+    """Regression test that ACA offsets match expected.
+
+    Expected values are the original flight values from 2022-11 analysis to expected
+    precision. The chandra_models version is (by default) current flight, so this test
+    ensures that any model updates do not introduce a regression.
+
+    Testing a new drift model here can be done with environment variables::
+
+      env CHANDRA_MODELS_REPO_DIR=$HOME/git/chandra_models \
+          CHANDRA_MODELS_DEFAULT_VERSION=aimpoint-drift-update  \
+      pytest -k test_drift
+
+    When a new drift model is released, the `aimpoint_regression_data.ecsv` file can
+    optionally be updated with the new values from the analysis notebook.
+    """
     kwargs = kwargs.copy()
     aca_offset_y = kwargs.pop("aca_offset_y")
     aca_offset_z = kwargs.pop("aca_offset_z")
+
+    # Test explicitly providing drift_pars. This should be exactly the same as the
+    # default handling.
+    if use_drift_pars:
+        kwargs["drift_pars"] = DRIFT_PARS_TEST
+        # Print info for use with `-s` flag to see what model is being used.
+        info = DRIFT_PARS_TEST["info"]
+        repo_path = info["repo_path"]
+        version = info["version"]
+        md5 = info["md5"]
+        print(f"{repo_path=} {version=} {md5=}")
+
     offsets = drift.get_aca_offsets(**kwargs)
     dy = offsets[0] - aca_offset_y
     dz = offsets[1] - aca_offset_z
@@ -70,7 +99,7 @@ def test_get_aca_offsets(kwargs, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "t, t_ccd, expected_dy, expected_dz",
+    "date, t_ccd, expected_dy, expected_dz",
     [
         ("2018:284", -10.0, -7.50, -5.30),
         ("2018:286", -10.0, 5.01, 0.75),
@@ -78,11 +107,13 @@ def test_get_aca_offsets(kwargs, monkeypatch):
         ("2022:295", -10, 17.44, 2.90),
     ],
 )
-def test_get_fid_offset(t, t_ccd, expected_dy, expected_dz):
+@pytest.mark.parametrize("use_drift_pars", [True, False])
+def test_get_fid_offset(date, t_ccd, expected_dy, expected_dz, use_drift_pars):
     """
     Test that the get_fid_offset function returns expected values for a few inputs.
     """
-    dy, dz = drift.get_fid_offset(t, t_ccd)
+    kwargs = {"drift_pars": DRIFT_PARS_TEST} if use_drift_pars else {}
+    dy, dz = drift.get_fid_offset(date, t_ccd, **kwargs)
     assert np.isclose(dy, expected_dy, atol=0.01)
     assert np.isclose(dz, expected_dz, atol=0.01)
 

--- a/chandra_aca/tests/test_drift.py
+++ b/chandra_aca/tests/test_drift.py
@@ -12,6 +12,7 @@ from chandra_aca import drift
 # See test_get_aca_offsets() for how to test a new drift model.
 DRIFT_PARS_TEST = LazyDict(drift.load_drift_pars)
 
+
 def test_get_aca_offsets_legacy():
     """
     Legacy test that ACA offsets are reasonable, and regression test particular values


### PR DESCRIPTION
## Description

This adds a new optional kwarg `drift_pars`to the `get_aca_offsets` and `get_fid_offset` functions. This makes it easier to develop and functionally test a new drift model without having to put that model into branch of `chandra_models`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
New kwarg.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new tests)

#### Flight chandra_models:
```
(ska3) ➜  chandra_aca git:(add-drift-pars-kwargs) git rev-parse --short HEAD
df74975
(ska3) ➜  chandra_aca git:(add-drift-pars-kwargs) pytest -s                 
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 250 items                                                                                                                                       

chandra_aca/tests/test_aca_image.py ..................
chandra_aca/tests/test_all.py .testing 625 row/col pairs match to 0.05 arcsec
..testing 622 yang/zang pairs match to 0.05 pixels
.....................
chandra_aca/tests/test_attitude.py .............................................................
chandra_aca/tests/test_dark_model.py ............
chandra_aca/tests/test_dark_subtract.py ........
chandra_aca/tests/test_drift.py 
.repo_path='/Users/aldcroft/ska/data/chandra_models' version='3.63' md5='ac8ca75533be18643359d2e0889019ca'
   ...
.repo_path='/Users/aldcroft/ska/data/chandra_models' version='3.63' md5='ac8ca75533be18643359d2e0889019ca'
..............................
chandra_aca/tests/test_maude_decom.py .........................
chandra_aca/tests/test_planets.py ...............
chandra_aca/tests/test_psf.py ...
chandra_aca/tests/test_residuals.py .....
chandra_aca/tests/test_star_probs.py .................................

================================================================== 250 passed in 40.05s ===================================================================
```

#### Test chandra_models
With `$HOME/git/chandra_models` including the branch for https://github.com/sot/chandra_models/pull/146:
```
(ska3) ➜  chandra_aca git:(add-drift-pars-kwargs) env CHANDRA_MODELS_REPO_DIR=${HOME}/git/chandra_models \        
  CHANDRA_MODELS_DEFAULT_VERSION=aimpoint-drift-update \
  pytest -s
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 250 items                                                                                                                                       

chandra_aca/tests/test_aca_image.py ..................
chandra_aca/tests/test_all.py .testing 625 row/col pairs match to 0.05 arcsec
..testing 622 yang/zang pairs match to 0.05 pixels
.....................
chandra_aca/tests/test_attitude.py .............................................................
chandra_aca/tests/test_dark_model.py ............
chandra_aca/tests/test_dark_subtract.py ........
chandra_aca/tests/test_drift.py 
.repo_path='/Users/aldcroft/git/chandra_models' version='aimpoint-drift-update' md5='918ed8df7b6358a1c1bdf6b03edac669'
  ...
.repo_path='/Users/aldcroft/git/chandra_models' version='aimpoint-drift-update' md5='918ed8df7b6358a1c1bdf6b03edac669'
..............................
chandra_aca/tests/test_maude_decom.py .........................
chandra_aca/tests/test_planets.py ...............
chandra_aca/tests/test_psf.py ...
chandra_aca/tests/test_residuals.py .....
chandra_aca/tests/test_star_probs.py .................................

================================================================== 250 passed in 32.09s ===================================================================
```
MD5 sum of model file in [`aimpoint_mon`](https://github.com/sot/aimpoint_mon/pull/30):
```
 md5 ~/git/aimpoint_mon/aca_drift_model.json 
MD5 (/Users/aldcroft/git/aimpoint_mon/aca_drift_model.json) = 918ed8df7b6358a1c1bdf6b03edac669
```


Independent check of unit tests by Jean
- [x] Mac
```
(ska3) flame:chandra_aca jean$ pytest
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 250 items                                                                                                                                                                            

chandra_aca/tests/test_aca_image.py ..................                                                                                                                                   [  7%]
chandra_aca/tests/test_all.py ........................                                                                                                                                   [ 16%]
chandra_aca/tests/test_attitude.py .............................................................                                                                                         [ 41%]
chandra_aca/tests/test_dark_model.py ............                                                                                                                                        [ 46%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                                                                         [ 49%]
chandra_aca/tests/test_drift.py ..............................................                                                                                                           [ 67%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                                                          [ 77%]
chandra_aca/tests/test_planets.py ...............                                                                                                                                        [ 83%]
chandra_aca/tests/test_psf.py ...                                                                                                                                                        [ 84%]
chandra_aca/tests/test_residuals.py ss...                                                                                                                                                [ 86%]
chandra_aca/tests/test_star_probs.py .................................                                                                                                                   [100%]

======================================================================================= warnings summary =======================================================================================
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 248 passed, 2 skipped, 4 warnings in 45.95s ==========================================================================
(ska3) flame:chandra_aca jean$ git rev-parse HEAD
52661a12d16081dc723b443dd870db2c569fb54c
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

