### PR TITLE
Don't fetch ccd temperature if bgsub=False

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -908,14 +908,16 @@ def get_aca_images(
     # Get aca images over the time range
     if source == "maude":
         imgs_table = chandra_aca.maude_decom.get_aca_images(start, stop, **maude_kwargs)
-        t_ccds = chandra_aca.dark_subtract.get_tccd_data(
-            imgs_table["TIME"], source=source, **maude_kwargs
-        )
+        if bgsub:
+            t_ccds = chandra_aca.dark_subtract.get_tccd_data(
+                imgs_table["TIME"], source=source, **maude_kwargs
+            )
     elif source == "cxc":
         imgs_table = mica.archive.aca_l0.get_aca_images(start, stop)
-        t_ccds = chandra_aca.dark_subtract.get_tccd_data(
-            imgs_table["TIME"], source=source
-        )
+        if bgsub:
+            t_ccds = chandra_aca.dark_subtract.get_tccd_data(
+                imgs_table["TIME"], source=source
+            )
     else:
         raise ValueError(f"source must be 'maude' or 'cxc', not {source}")
 

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -918,10 +918,13 @@ def get_aca_images(
     # Get images
     imgs_table = get_aca_images_func(start, stop, **maude_kwargs)
 
-    # Get background subtracted values if bgsub is True.
-    # There's nothing to do if there are no images (len(imgs_table) == 0),
-    # so special case that.
-    if bgsub and len(imgs_table) > 0:
+    # If bgsub is False, then just return the table as-is.
+    if not bgsub:
+        return imgs_table
+
+    # If bgsub is True, then calculate and add to the table.
+    # If the table has zero length then just add the columns with zero length.
+    if len(imgs_table) > 0:
         dark_data = mica.archive.aca_dark.get_dark_cal_props(
             imgs_table["TIME"].min(),
             select="nearest",
@@ -942,8 +945,7 @@ def get_aca_images(
         imgs_table["IMG_BGSUB"] = imgs_bgsub
         imgs_table["IMG_DARK"] = imgs_dark
         imgs_table["T_CCD_SMOOTH"] = t_ccds
-
-    if bgsub and len(imgs_table) == 0:
+    else:
         # Add the columns to the table even if there are no rows
         imgs_table["IMG_BGSUB"] = np.zeros(shape=(0, 8, 8))
         imgs_table["IMG_DARK"] = np.zeros(shape=(0, 8, 8))

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -18,7 +18,7 @@ __all__ = [
 
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_tccd_data(
-    times, smooth_window=30, median_window=3, source="maude", maude_channel=None
+    times, smooth_window=30, median_window=3, source="maude", channel=None
 ):
     """
     Get the CCD temperature for given times and interpolate and smooth.
@@ -36,7 +36,7 @@ def get_tccd_data(
         Median filter window to remove outliers (default=3).
     smooth_window : int, optional
         Smooth data using a hanning window of this length in samples (default=30).
-    maude_channel : str, optional
+    channel : str, optional
         Maude channel to use (default is flight).
 
     Returns
@@ -60,8 +60,8 @@ def get_tccd_data(
     if source == "maude":
         # Override the cheta data_source to be explicit about maude source.
         data_source = "maude allow_subset=False"
-        if maude_channel is not None:
-            data_source += f" channel={maude_channel}"
+        if channel is not None:
+            data_source += f" channel={channel}"
         with fetch_sci.data_source(data_source):
             dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
     elif source == "cxc":

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -494,9 +494,37 @@ def test_flicker_test_sequence():
 def test_get_short_range_aca_images():
     date = "2025:120:03:59:29.057"
     images = chandra_aca.aca_image.get_aca_images(
-        start=date, stop=CxoTime(date) + 7 * u.s, bgsub=False
+        start=date, stop=CxoTime(date) + 7 * u.s, source="maude", bgsub=False
     )
     assert len(images) == 16
+
+
+def test_get_aca_image_maude_channel():
+    # This is a SIM time when we had 4x4 images in all slots
+    date = "2025:071:15:15:20.020"
+    images_asvt = chandra_aca.aca_image.get_aca_images(
+        start=date,
+        stop=CxoTime(date) + 7 * u.s,
+        source="maude",
+        bgsub=False,
+        channel="ASVT",
+    )
+    assert len(images_asvt) == 56
+    # This is a 4x4
+    assert np.count_nonzero(~images_asvt[0]["IMG"].mask) == 16
+
+    # For the same times in flight these are different
+    images_flight = chandra_aca.aca_image.get_aca_images(
+        start=date,
+        stop=CxoTime(date) + 7 * u.s,
+        source="maude",
+        bgsub=False,
+        channel="FLIGHT",
+    )
+    # This is 8x8
+    assert np.count_nonzero(~images_flight[0]["IMG"].mask) == 64
+    # and there are fewer images
+    assert len(images_flight) == 16
 
 
 def images_check_range(start, stop, img_table, *, bgsub):

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
 
+import astropy.units as u
 import mica.common
 import numpy as np
 import pytest
@@ -488,6 +489,14 @@ def test_flicker_test_sequence():
             ]
         ),
     )
+
+
+def test_get_short_range_aca_images():
+    date = "2025:120:03:59:29.057"
+    images = chandra_aca.aca_image.get_aca_images(
+        start=date, stop=CxoTime(date) + 7 * u.s, bgsub=False
+    )
+    assert len(images) == 16
 
 
 def images_check_range(start, stop, img_table, *, bgsub):


### PR DESCRIPTION
## Description

In chandra_aca.aca_images.get_aca_images, don't fetch ccd temperature if bgsub=False.

The ccd temperature is only used if bgsub=True and since before this fix the fetching was happening even if bgsub=False, that required a minimum of 30 samples for the default get_tccd_data with default smoothing.  And none of this was coming back in useful error messages if the user tried to fetch a smaller set of images with bgsub=False.

```
----> 1 images = get_aca_images(start=CxoTime(date) - 30 * u.s,
      2 stop=CxoTime(date), source="maude")
...
ValueError: Input vector needs to be bigger than window size.
```


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This changes the name of the keyward argument in get_tccd_data from "maude_channel" to "channel" to match the kwarg used in other methods.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
3ba13b03cd435ed8176bd5c5a990927e8571ad84
(ska3-latest) flame:chandra_aca jean$ pytest
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 252 items                                                                                                                                          

chandra_aca/tests/test_aca_image.py ....................                                                                                               [  7%]
chandra_aca/tests/test_all.py ........................                                                                                                 [ 17%]
chandra_aca/tests/test_attitude.py .............................................................                                                       [ 41%]
chandra_aca/tests/test_dark_model.py ............                                                                                                      [ 46%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                                       [ 49%]
chandra_aca/tests/test_drift.py ..............................................                                                                         [ 67%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                        [ 77%]
chandra_aca/tests/test_planets.py ...............                                                                                                      [ 83%]
chandra_aca/tests/test_psf.py ...                                                                                                                      [ 84%]
chandra_aca/tests/test_residuals.py ss...                                                                                                              [ 86%]
chandra_aca/tests/test_star_probs.py .................................                                                                                 [100%]

====================================================================== warnings summary
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
