### PR TITLE
Change time range in short image test

### DIFF
--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -494,7 +494,7 @@ def test_flicker_test_sequence():
 def test_get_short_range_aca_images():
     date = "2025:120:03:59:29.057"
     images = chandra_aca.aca_image.get_aca_images(
-        start=date, stop=CxoTime(date) + 7 * u.s, source="maude", bgsub=False
+        start=date, stop=CxoTime(date) + 8 * u.s, source="maude", bgsub=False
     )
     assert len(images) == 16
 


### PR DESCRIPTION
## Description

Change time range in short image test.

I'm not really sure why this test passed for the original PR and does not pass now without changing the test, but perhaps the MAUDE data was not stable in the interval.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #192 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:chandra_aca jean$ pytest
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 252 items                                                                                                                                                                                      

chandra_aca/tests/test_aca_image.py ....................                                                                                                                                           [  7%]
chandra_aca/tests/test_all.py ........................                                                                                                                                             [ 17%]
chandra_aca/tests/test_attitude.py .............................................................                                                                                                   [ 41%]
chandra_aca/tests/test_dark_model.py ............                                                                                                                                                  [ 46%]
chandra_aca/tests/test_dark_subtract.py ........                                                                                                                                                   [ 49%]
chandra_aca/tests/test_drift.py ..............................................                                                                                                                     [ 67%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                                                                    [ 77%]
chandra_aca/tests/test_planets.py ...............                                                                                                                                                  [ 83%]
chandra_aca/tests/test_psf.py ...                                                                                                                                                                  [ 84%]
chandra_aca/tests/test_residuals.py ss...                                                                                                                                                          [ 86%]
chandra_aca/tests/test_star_probs.py .................................                                                                                                                             [100%]

============================================================================================ warnings summary ============================================================================================
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
chandra_aca/chandra_aca/tests/test_residuals.py::test_obc
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 250 passed, 2 skipped, 4 warnings in 68.87s (0:01:08) ==========================================================================
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
6de622151432d0dc748d32aa820cd29b219fb605
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
