### PR TITLE
Fix bug quoting the maude channel for cheta.fetch

### DIFF
--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -61,7 +61,7 @@ def get_tccd_data(
         # Override the cheta data_source to be explicit about maude source.
         data_source = "maude allow_subset=False"
         if channel is not None:
-            data_source += f" channel={channel}"
+            data_source += f" channel='{channel}'"
         with fetch_sci.data_source(data_source):
             dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
     elif source == "cxc":

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -499,6 +499,19 @@ def test_get_short_range_aca_images():
     assert len(images) == 16
 
 
+def test_get_asvt_tccd_aca_images():
+    date = "2022:045:09:23:12.076"
+    images = chandra_aca.aca_image.get_aca_images(
+        start=date,
+        stop=CxoTime(date) + 8 * u.s,
+        source="maude",
+        bgsub=True,
+        channel="ASVT",
+    )
+    assert len(images) == 16
+    assert np.isclose(images["T_CCD_SMOOTH"][0], 0.21606728395062028)
+
+
 def test_get_aca_image_maude_channel():
     # This is a SIM time when we had 4x4 images in all slots
     date = "2025:071:15:15:20.020"

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -170,6 +170,14 @@ def test_get_tccd_data():
         assert np.allclose(t_ccd_maude, t_ccd)
 
 
+def test_get_tccd_data_asvt():
+    start = "2025:012:11:28:11.641"
+    stop = "2025:012:11:29:11.641"
+    times = CxoTime.linspace(start, stop, 30)
+    t_ccd_maude_asvt = get_tccd_data(times.secs, source="maude", channel="ASVT")
+    assert np.allclose(t_ccd_maude_asvt, -1.78, atol=0.25, rtol=0)
+
+
 def test_get_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
     """
     Confirm the pattern of dark current images matches the reference.


### PR DESCRIPTION
## Description

Fix bug quoting the maude channel for cheta.fetch

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
101b9923c5d4e8da53e5444e10d0a18f76e04ae6
(ska3-latest) flame:chandra_aca jean$ pytest
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 254 items                                                                                                                                          

chandra_aca/tests/test_aca_image.py .....................                                                                                              [  8%]
chandra_aca/tests/test_all.py ........................                                                                                                 [ 17%]
chandra_aca/tests/test_attitude.py .............................................................                                                       [ 41%]
chandra_aca/tests/test_dark_model.py ............                                                                                                      [ 46%]
chandra_aca/tests/test_dark_subtract.py .........                                                                                                      [ 50%]
chandra_aca/tests/test_drift.py ..............................................                                                                         [ 68%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                        [ 77%]
chandra_aca/tests/test_planets.py ...............                                                                                                      [ 83%]
chandra_aca/tests/test_psf.py ...                                                                                                                      [ 85%]
chandra_aca/tests/test_residuals.py ss...                                                                                                              [ 87%]
chandra_aca/tests/test_star_probs.py .................................                                                                                 [100%]

====================================================================== warnings summary
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Adds two unit tests that use maude plus ASVT and use cheta.fetch.
