### PR TITLE
Add IMGSIZE to maude aca images

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -860,8 +860,15 @@ def get_aca_images(
 
     The returned table of ACA images and ancillary data will include the default
     columns returned by chandra_aca.maude_decom.get_aca_images or
-    mica.archive.aca_l0.get_aca_images. If bgsub is True (the default) then the
-    table will also include columns::
+    mica.archive.aca_l0.get_aca_images. Additionally, an IMGSIZE column will be
+    added to the maude_decom aca_images so images from either source will have
+    that column::
+
+             name            dtype  unit
+      --------------------- ------- -----------
+         IMGSIZE              int32  pixels
+
+    If bgsub is True then the table will also include columns::
 
              name            dtype  unit
       --------------------- ------- -----------
@@ -917,6 +924,13 @@ def get_aca_images(
 
     # Get images
     imgs_table = get_aca_images_func(start, stop, **maude_kwargs)
+
+    # Add an IMGSIZE column if not present (maude)
+    # IMGTYPE 4 -> 8, 1 -> 6, 0 -> 4
+    if "IMGSIZE" not in imgs_table.colnames:
+        imgs_table["IMGSIZE"] = np.zeros(len(imgs_table), dtype=np.int32)
+        for itype, size in zip([4, 1, 0], [8, 6, 4], strict=True):
+            imgs_table["IMGSIZE"][imgs_table["IMGTYPE"] == itype] = size
 
     # If bgsub is False, then just return the table as-is.
     if not bgsub:

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -525,6 +525,8 @@ def test_get_aca_image_maude_channel():
     assert len(images_asvt) == 56
     # This is a 4x4
     assert np.count_nonzero(~images_asvt[0]["IMG"].mask) == 16
+    assert np.all(images_asvt["IMGSIZE"] == 4)
+    assert np.all(images_asvt["IMGTYPE"] == 0)
 
     # For the same times in flight these are different
     images_flight = chandra_aca.aca_image.get_aca_images(
@@ -538,6 +540,8 @@ def test_get_aca_image_maude_channel():
     assert np.count_nonzero(~images_flight[0]["IMG"].mask) == 64
     # and there are fewer images
     assert len(images_flight) == 16
+    assert np.all(images_flight["IMGSIZE"] == 8)
+    assert np.all(images_flight["IMGTYPE"] == 4)
 
 
 def images_check_range(start, stop, img_table, *, bgsub):

--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,4 +1,3 @@
-# Copied originally from pandas. This config requires ruff >= 0.2.
 target-version = "py312"
 
 # fix = true
@@ -42,10 +41,13 @@ lint.ignore = [
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
+  "PLC0415", # `import` should be at the top-level of a file
+  "PLW1641", # Class implements `__hash__` if `__eq__` is implemented
 ]
 
 extend-exclude = [
   "docs",
+  "build",
 ]
 
 [lint.pycodestyle]


### PR DESCRIPTION
## Description

Add IMGSIZE to maude aca images


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds new column to images returned via get_aca_images .

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
07d892b9a20feb0dc4ae8a3261d36abfcef74e43
(ska3-latest) flame:chandra_aca jean$ pytest
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 254 items                                                                                                                                           

chandra_aca/tests/test_aca_image.py .....................                                                                                               [  8%]
chandra_aca/tests/test_all.py ........................                                                                                                  [ 17%]
chandra_aca/tests/test_attitude.py .............................................................                                                        [ 41%]
chandra_aca/tests/test_dark_model.py ............                                                                                                       [ 46%]
chandra_aca/tests/test_dark_subtract.py .........                                                                                                       [ 50%]
chandra_aca/tests/test_drift.py ..............................................                                                                          [ 68%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                         [ 77%]
chandra_aca/tests/test_planets.py ...............                                                                                                       [ 83%]
chandra_aca/tests/test_psf.py ...                                                                                                                       [ 85%]
chandra_aca/tests/test_residuals.py ss...                                                                                                               [ 87%]
chandra_aca/tests/test_star_probs.py .................................                                                                                  [100%]

====================================================================== warnings summary
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
