### PR TITLE
Add function to compute earth and moon limb angles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.9
+  rev: v0.15.13
   hooks:
     # Run the linter.
     - id: ruff

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -824,6 +824,12 @@ def get_earth_moon_limb_angles(
     stop = CxoTime(np.max(times)) + 6 * u.min
 
     q_att_msid = fetch.Msid("quat_aoattqt", start, stop)
+    if q_att_msid.times[-1] < times[-1]:
+        raise ValueError(
+            f"Attitude quaternion data does extend through requested last "
+            f"time {CxoTime(times[-1]).date}. Last available quaternion time "
+            f"is {CxoTime(q_att_msid.times[-1]).date}."
+        )
     orbitephem = {}
     orbitephem["x"] = fetch.Msid("orbitephem0_x", start, stop)
     orbitephem["y"] = fetch.Msid("orbitephem0_y", start, stop)

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -801,8 +801,8 @@ def get_earth_moon_limb_angles(
     the given observation times. The limb angle is the angle from the ACA boresight to
     the limb of the body.
 
-    The function fetches the necessary ephemeris data (Chandra position, Moon position,
-    and attitude quaternion) from the cheta telemetry archive.
+    The function fetches the necessary predictive ephemeris data (Chandra position, Moon
+    position, and attitude quaternion) from the cheta telemetry archive.
 
     Parameters
     ----------
@@ -840,7 +840,7 @@ def get_earth_moon_limb_angles(
     lunarephem["y"] = fetch.Msid("lunarephem0_y", start, stop)
     lunarephem["z"] = fetch.Msid("lunarephem0_z", start, stop)
 
-    # Interpolate ephem vectors to mon_imgs["times"]
+    # Interpolate ephem vectors to times
     p_chandra_eci = np.zeros(shape=(n_imgs, 3))
     p_moon_eci = np.zeros(shape=(n_imgs, 3))
     for ii, axis in enumerate(["x", "y", "z"]):

--- a/chandra_aca/planets.py
+++ b/chandra_aca/planets.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Functions for planet position relative to Chandra, Earth, or Solar System Barycenter.
+Solar system object positions relative to Chandra, Earth, or Solar System Barycenter.
 
 Estimated accuracy of planet coordinates (RA, Dec) is as follows, where the JPL
 Horizons positions are used as the "truth".
@@ -44,6 +44,7 @@ __all__ = (
     "get_planet_angular_sep",
     "get_earth_boresight_angle",
     "get_earth_blocks",
+    "get_earth_moon_limb_angles",
     "EarthBoresightAngles",
     "NoEphemerisError",
     "GET_PLANET_ECI_ERRORS",
@@ -748,3 +749,109 @@ def get_earth_blocks(
     eba = get_earth_boresight_angle(start, stop)
     blocks = logical_intervals(eba.times.secs, eba.earth_limb_angle < min_limb_angle)
     return blocks
+
+
+def _get_limb_angle(
+    ss_body_name: str,
+    q_att_t: np.ndarray,
+    p_ss_body_chandra_eci: np.ndarray,
+) -> np.ndarray[np.float32]:
+    """Helper function to get limb angle of Chandra pointing from Solar System object.
+
+    Parameters
+    ----------
+    ss_body_name : str
+        Name of Solar System body ('earth' or 'moon')
+    q_att_t : np.ndarray
+        Attitude transform matrices (n_times, 3, 3) from inertial to Chandra frame
+    p_ss_body_chandra_eci : np.ndarray
+        Position vectors (n_times, 3) of Solar System body relative to Chandra in ECI
+        coordinates
+
+    Returns
+    -------
+    ss_body_limb_angle : np.ndarray[np.float32]
+        Limb angle of Solar System body in degrees (n_times,)
+    """
+    RADIUS_SS_BODY = {
+        "earth": 6371.0 * 1000,  # m
+        "moon": 1737.4 * 1000,
+    }
+    # Vector from Chandra to SS body in Chandra body coordinates:
+    # Q_att^-1 * p_ss_body_chandra_eci
+    p_ss_body_body = np.einsum(
+        "ijk,ik->ij", q_att_t.transpose((0, 2, 1)), p_ss_body_chandra_eci
+    )
+    ss_body_distance = np.linalg.norm(p_ss_body_body, axis=1)
+    # Unit vector
+    p_ss_body_body_unit = p_ss_body_body / ss_body_distance[:, None]
+    ss_body_angle = np.rad2deg(np.arccos(np.clip(p_ss_body_body_unit[:, 0], -1.0, 1.0)))
+    open_angle = np.rad2deg(np.arcsin(RADIUS_SS_BODY[ss_body_name] / ss_body_distance))
+    ss_body_limb_angle = ss_body_angle - open_angle
+
+    return ss_body_limb_angle.astype(np.float32)
+
+
+def get_earth_moon_limb_angles(
+    times: CxoTimeLike | list | np.ndarray,
+) -> tuple[np.ndarray[np.float32], np.ndarray[np.float32]]:
+    """Get Earth and Moon limb angles for monitor images at specified times.
+
+    This function calculates the limb angles of Earth and Moon as seen from Chandra at
+    the given observation times. The limb angle is the angle from the ACA boresight to
+    the limb of the body.
+
+    The function fetches the necessary ephemeris data (Chandra position, Moon position,
+    and attitude quaternion) from the cheta telemetry archive.
+
+    Parameters
+    ----------
+    times : CxoTimeLike | list | np.ndarray
+        Time or times for which to calculate limb angles. Can be a CxoTime object,
+        scalar time, list of times, or numpy array of times.
+
+    Returns
+    -------
+    tuple[np.ndarray[np.float32], np.ndarray[np.float32]]
+        A tuple of (earth_limb_angle, moon_limb_angle) where each is a numpy array of
+        float32 values in degrees. The array length matches the number of input times.
+    """
+    from cheta import fetch
+
+    times = np.atleast_1d(CxoTime(times).secs)
+    n_imgs = len(times)
+    start = CxoTime(np.min(times)) - 6 * u.min
+    stop = CxoTime(np.max(times)) + 6 * u.min
+
+    q_att_msid = fetch.Msid("quat_aoattqt", start, stop)
+    orbitephem = {}
+    orbitephem["x"] = fetch.Msid("orbitephem0_x", start, stop)
+    orbitephem["y"] = fetch.Msid("orbitephem0_y", start, stop)
+    orbitephem["z"] = fetch.Msid("orbitephem0_z", start, stop)
+
+    lunarephem = {}
+    lunarephem["x"] = fetch.Msid("lunarephem0_x", start, stop)
+    lunarephem["y"] = fetch.Msid("lunarephem0_y", start, stop)
+    lunarephem["z"] = fetch.Msid("lunarephem0_z", start, stop)
+
+    # Interpolate ephem vectors to mon_imgs["times"]
+    p_chandra_eci = np.zeros(shape=(n_imgs, 3))
+    p_moon_eci = np.zeros(shape=(n_imgs, 3))
+    for ii, axis in enumerate(["x", "y", "z"]):
+        p_chandra_eci[:, ii] = np.interp(
+            x=times, xp=orbitephem[axis].times, fp=orbitephem[axis].vals
+        )
+        p_moon_eci[:, ii] = np.interp(
+            x=times, xp=lunarephem[axis].times, fp=lunarephem[axis].vals
+        )
+
+    q_att_msid.interpolate(times=times)
+    q_att_t = q_att_msid.vals.transform
+
+    p_moon_chandra_eci = p_moon_eci - p_chandra_eci
+    p_earth_chandra_eci = -p_chandra_eci
+
+    earth_limb_angle = _get_limb_angle("earth", q_att_t, p_earth_chandra_eci)
+    moon_limb_angle = _get_limb_angle("moon", q_att_t, p_moon_chandra_eci)
+
+    return earth_limb_angle, moon_limb_angle

--- a/chandra_aca/tests/test_planets.py
+++ b/chandra_aca/tests/test_planets.py
@@ -22,6 +22,13 @@ from chandra_aca.transform import eci_to_radec, radec_to_yagzag
 
 HAS_INTERNET = has_internet()
 
+EXP_EARTH_LIMB_ANGLE = np.array(
+    [43.9, 48.8, 53.8, 58.9, 63.9, 68.8, 73.4, 77.2, 79.8, 81.6, 82.4]
+)
+EXP_MOON_LIMB_ANGLE = np.array(
+    [30.4, 25.6, 20.6, 15.6, 10.4, 5.3, 0.7, 3.8, 7.0, 9.3, 10.5]
+)
+
 
 @pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
 def test_planet_positions():
@@ -257,7 +264,7 @@ def test_get_earth_moon_limb_angles_regression():
     assert np.all(
         np.isclose(
             earth_limb_angle,
-            [43.9, 48.8, 53.8, 58.9, 63.9, 68.8, 73.4, 77.2, 79.8, 81.6, 82.4],
+            EXP_EARTH_LIMB_ANGLE,
             rtol=0,
             atol=0.05,
         )
@@ -265,7 +272,38 @@ def test_get_earth_moon_limb_angles_regression():
     assert np.all(
         np.isclose(
             moon_limb_angle,
-            [30.4, 25.6, 20.6, 15.6, 10.4, 5.3, 0.7, 3.8, 7.0, 9.3, 10.5],
+            EXP_MOON_LIMB_ANGLE,
+            rtol=0,
+            atol=0.05,
+        )
+    )
+    assert earth_limb_angle.shape == times.shape
+    assert moon_limb_angle.shape == times.shape
+    assert earth_limb_angle.dtype == np.float32
+    assert moon_limb_angle.dtype == np.float32
+
+
+def test_get_earth_moon_limb_angles_scalar():
+    ela, mla = get_earth_moon_limb_angles("2025:016:13:20:00")
+    assert np.isclose(ela, EXP_EARTH_LIMB_ANGLE[0], rtol=0, atol=0.05)
+    assert np.isclose(mla, EXP_MOON_LIMB_ANGLE[0], rtol=0, atol=0.05)
+
+
+def test_get_earth_moon_limb_angles_list():
+    times = ["2025:016:13:20:00", "2025:016:13:40:00"]
+    ela, mla = get_earth_moon_limb_angles(times)
+    assert np.all(
+        np.isclose(
+            ela,
+            EXP_EARTH_LIMB_ANGLE[[0, -1]],
+            rtol=0,
+            atol=0.05,
+        )
+    )
+    assert np.all(
+        np.isclose(
+            mla,
+            EXP_MOON_LIMB_ANGLE[[0, -1]],
             rtol=0,
             atol=0.05,
         )

--- a/chandra_aca/tests/test_planets.py
+++ b/chandra_aca/tests/test_planets.py
@@ -11,6 +11,7 @@ from testr.test_helper import has_internet
 from chandra_aca.planets import (
     convert_time_format_spk,
     get_earth_blocks,
+    get_earth_moon_limb_angles,
     get_planet_angular_sep,
     get_planet_barycentric,
     get_planet_chandra,
@@ -241,3 +242,31 @@ def test_earth_boresight():
 
     blocks = get_earth_blocks(start, stop, min_limb_angle=10.0)
     assert blocks["datestart", "datestop", "duration"].pformat() == exp
+
+
+def test_get_earth_moon_limb_angles_regression():
+    """Limited regression test for this function.
+
+    This has been functionally tested more fully in the maneuver monitor window
+    processing and analysis. These data values qualitatively match those from the
+    functions used there.
+    """
+    times = CxoTime.linspace("2025:016:13:20:00", "2025:016:13:40:00", 10)
+    earth_limb_angle, moon_limb_angle = get_earth_moon_limb_angles(times)
+
+    assert np.all(
+        np.isclose(
+            earth_limb_angle,
+            [43.9, 48.8, 53.8, 58.9, 63.9, 68.8, 73.4, 77.2, 79.8, 81.6, 82.4],
+            rtol=0,
+            atol=0.05,
+        )
+    )
+    assert np.all(
+        np.isclose(
+            moon_limb_angle,
+            [30.4, 25.6, 20.6, 15.6, 10.4, 5.3, 0.7, 3.8, 7.0, 9.3, 10.5],
+            rtol=0,
+            atol=0.05,
+        )
+    )


### PR DESCRIPTION
## Description

This adds a function that computes the earth and moon limb angles for given times. It is basically a copy of a functions used in the `ska_trend/manvr_mon_images/update-manvr-mon-images.ipynb notebook`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-dev) ➜  chandra_aca git:(earth-moon-limb-angles) git rev-parse --short HEAD      
5c63f28
(ska3-dev) ➜  chandra_aca git:(earth-moon-limb-angles) pytest 
========================================= test session starts ==========================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 271 items                                                                                    

chandra_aca/tests/test_aca_image.py .....................                                        [  7%]
chandra_aca/tests/test_attitude.py ............................................................. [ 30%]
                                                                                                 [ 30%]
chandra_aca/tests/test_dark_model.py ............                                                [ 34%]
chandra_aca/tests/test_dark_subtract.py .........                                                [ 38%]
chandra_aca/tests/test_drift.py ..............................................                   [ 54%]
chandra_aca/tests/test_manvr_mon_images.py .......                                               [ 57%]
chandra_aca/tests/test_maude_decom.py .........................                                  [ 66%]
chandra_aca/tests/test_planets.py ....................                                           [ 74%]
chandra_aca/tests/test_psf.py ...                                                                [ 75%]
chandra_aca/tests/test_residuals.py .....                                                        [ 77%]
chandra_aca/tests/test_star_probs.py .................................                           [ 89%]
chandra_aca/tests/test_transform.py .............................                                [100%]

========================================= 271 passed in 39.49s =========================================
```
Independent check of unit tests by Jean
- [x] linux
```
(ska3-latest) jeanconn-kady> pytest
============================================= test session starts ==============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.1
collected 271 items                                                                                            

chandra_aca/tests/test_aca_image.py .....................                                                [  7%]
chandra_aca/tests/test_attitude.py .............................................................         [ 30%]
chandra_aca/tests/test_dark_model.py ............                                                        [ 34%]
chandra_aca/tests/test_dark_subtract.py .........                                                        [ 38%]
chandra_aca/tests/test_drift.py ..............................................                           [ 54%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                       [ 57%]
chandra_aca/tests/test_maude_decom.py .........................                                          [ 66%]
chandra_aca/tests/test_planets.py ....................                                                   [ 74%]
chandra_aca/tests/test_psf.py ...                                                                        [ 75%]
chandra_aca/tests/test_residuals.py .....                                                                [ 77%]
chandra_aca/tests/test_star_probs.py .................................                                   [ 89%]
chandra_aca/tests/test_transform.py .............................                                        [100%]

======================================== 271 passed in 79.18s (0:01:19) ========================================
(ska3-latest) jeanconn-kady> git rev-parse HEAD
56ce41ea3f715a6795351c6ddfad05634321020f
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functional testing in maneurver monitor window analysis.
