### PR TITLE
Add function to get CCD quadrant from row, col

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1015,7 +1015,7 @@ def get_ccd_quadrant(row, col, pix_zero_loc="center"):
     elif pix_zero_loc != "edge":
         raise ValueError("pix_zero_loc can be only 'edge' or 'center'")
 
-    quadrants = np.empty(shape=shape, dtype="<U1")
+    quadrants = np.empty(shape=shape, dtype="U1")
     quadrants[(row < 0) & (col >= 0)] = "a"
     quadrants[(row < 0) & (col < 0)] = "b"
     quadrants[(row >= 0) & (col >= 0)] = "c"

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -966,3 +966,55 @@ def get_aca_images(
         imgs_table["T_CCD_SMOOTH"] = np.zeros(shape=0)
 
     return imgs_table
+
+
+def get_ccd_quadrant(row, col, pix_zero_loc="center"):
+    """
+    Get CCD quadrant for given row and column.
+
+    For ``row`` and ``col`` values in the "edge" coordinate system where the center
+    of the CCD is at exactly (0.0, 0.0), the quadrants are defined as follows:
+
+    - a: row < 0 and col >= 0
+    - b: row < 0 and col < 0
+    - c: row >= 0 and col >= 0
+    - d: row >= 0 and col < 0
+
+    Parameters
+    ----------
+    row : float, np.ndarray[float]
+        Row value(s) of pixel(s)
+    col : float, np.ndarray[float]
+        Column value(s) of pixel(s)
+    pix_zero_loc : str
+        Location of pixel zero, either 'center' or 'edge'. Default is 'center'.
+
+    Returns
+    -------
+    quadrant : str or np.ndarray[str]
+        CCD quadrant ('a', 'b', 'c', or 'd') for each input row and column value. If
+        input row and col are scalars, returns a single string. If input row and col are
+        arrays, returns an array of strings with the same shape as the broadcasted shape
+        of row and col.
+    """
+    if pix_zero_loc == "center":
+        # Transform row/col values from 'center' convention to 'edge' convention, so
+        # that (0.0, 0.0) is the exact quadrant boundary center.
+        row = row + 0.5
+        col = col + 0.5
+    elif pix_zero_loc != "edge":
+        raise ValueError("pix_zero_loc can be only 'edge' or 'center'")
+
+    row, col = np.broadcast_arrays(np.asarray(row), np.asarray(col))
+    shape = row.shape
+
+    quadrants = np.empty(shape=shape, dtype="<U1")
+    quadrants[(row < 0) & (col >= 0)] = "a"
+    quadrants[(row < 0) & (col < 0)] = "b"
+    quadrants[(row >= 0) & (col >= 0)] = "c"
+    quadrants[(row >= 0) & (col < 0)] = "d"
+
+    if shape == ():
+        return quadrants.item()
+
+    return quadrants

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -997,6 +997,9 @@ def get_ccd_quadrant(row, col, pix_zero_loc="center"):
         arrays, returns an array of strings with the same shape as the broadcasted shape
         of row and col.
     """
+    row, col = np.broadcast_arrays(np.asarray(row), np.asarray(col))
+    shape = row.shape
+
     if pix_zero_loc == "center":
         # Transform row/col values from 'center' convention to 'edge' convention, so
         # that (0.0, 0.0) is the exact quadrant boundary center.
@@ -1004,9 +1007,6 @@ def get_ccd_quadrant(row, col, pix_zero_loc="center"):
         col = col + 0.5
     elif pix_zero_loc != "edge":
         raise ValueError("pix_zero_loc can be only 'edge' or 'center'")
-
-    row, col = np.broadcast_arrays(np.asarray(row), np.asarray(col))
-    shape = row.shape
 
     quadrants = np.empty(shape=shape, dtype="<U1")
     quadrants[(row < 0) & (col >= 0)] = "a"

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -18,7 +18,14 @@ from astropy.table import Table
 from cxotime import CxoTimeLike
 from ska_helpers import retry
 
-__all__ = ["ACAImage", "centroid_fm", "AcaPsfLibrary", "EIGHT_LABELS", "get_aca_images"]
+__all__ = [
+    "ACAImage",
+    "centroid_fm",
+    "AcaPsfLibrary",
+    "EIGHT_LABELS",
+    "get_aca_images",
+    "get_ccd_quadrant",
+]
 
 EIGHT_LABELS = np.array(
     [

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -9,7 +9,7 @@ from cxotime import CxoTime
 from mica.archive.aca_dark import get_dark_cal_props
 
 import chandra_aca.aca_image
-from chandra_aca.aca_image import ACAImage, centroid_fm
+from chandra_aca.aca_image import ACAImage, centroid_fm, get_ccd_quadrant
 
 im6 = np.arange(6**2).reshape((6, 6))
 im8 = np.arange(8**2).reshape((8, 8))
@@ -649,3 +649,35 @@ def test_get_aca_images_cxc_and_maude():
     assert np.allclose(img_table_maude["TIME"], img_table_cxc["TIME"])
     assert np.allclose(img_table_maude_bgsub["IMG"], img_table_cxc_bgsub["IMG"])
     assert np.allclose(img_table_maude_bgsub["TIME"], img_table_cxc_bgsub["TIME"])
+
+
+def test_get_ccd_quadrant():
+    assert get_ccd_quadrant(-1, 1) == "a"
+    assert get_ccd_quadrant(-1, -1) == "b"
+    assert get_ccd_quadrant(1, 1) == "c"
+    assert get_ccd_quadrant(1, -1) == "d"
+
+    # With pix_zero_loc='center', the pixel center at (0, 0) lies in quadrant c.
+    assert get_ccd_quadrant(0, 0) == "c"
+
+    # With pix_zero_loc='edge', the exact quadrant boundaries are at row=0 and col=0.
+    assert get_ccd_quadrant(-0.1, 0.1, pix_zero_loc="edge") == "a"
+    assert get_ccd_quadrant(-0.1, -0.1, pix_zero_loc="edge") == "b"
+    assert get_ccd_quadrant(0.1, 0.1, pix_zero_loc="edge") == "c"
+    assert get_ccd_quadrant(0.1, -0.1, pix_zero_loc="edge") == "d"
+
+    row = [-1, -1, 1, 1]
+    col = [1, -1, 1, -1]
+    assert np.all(get_ccd_quadrant(row, col) == np.array(["a", "b", "c", "d"]))
+
+    row = np.array([-0.1, -0.1, 0.1, 0.1])
+    col = np.array([0.1, -0.1, 0.1, -0.1])
+    assert np.all(
+        get_ccd_quadrant(row, col, pix_zero_loc="edge")
+        == np.array(["a", "b", "c", "d"])
+    )
+
+
+def test_get_ccd_quadrant_fail():
+    with pytest.raises(ValueError, match="pix_zero_loc"):
+        get_ccd_quadrant(0, 0, pix_zero_loc="bad")


### PR DESCRIPTION
## Description

This codifies the mapping from row, col to ACA CCD quadrant.

This is from the EQ-spec, where the diagram indicates `col, row` instead of the more common `row, col`.
<img width="339" height="341" alt="Screenshot 2026-05-21 at 1 43 07 PM" src="https://github.com/user-attachments/assets/8d4b82ec-ee22-4779-99bd-bcc73d6cebdf" />

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  chandra_aca git:(ccd-quadrant-map) git rev-parse --short HEAD
60af91a
(ska3) ➜  chandra_aca git:(ccd-quadrant-map) pytest
========================================= test session starts ==========================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 270 items                                                                                    

chandra_aca/tests/test_aca_image.py .......................                                      [  8%]
chandra_aca/tests/test_attitude.py ............................................................. [ 31%]
                                                                                                 [ 31%]
chandra_aca/tests/test_dark_model.py ............                                                [ 35%]
chandra_aca/tests/test_dark_subtract.py .........                                                [ 38%]
chandra_aca/tests/test_drift.py ..............................................                   [ 55%]
chandra_aca/tests/test_manvr_mon_images.py .......                                               [ 58%]
chandra_aca/tests/test_maude_decom.py .........................                                  [ 67%]
chandra_aca/tests/test_planets.py .................                                              [ 74%]
chandra_aca/tests/test_psf.py ...                                                                [ 75%]
chandra_aca/tests/test_residuals.py .....                                                        [ 77%]
chandra_aca/tests/test_star_probs.py .................................                           [ 89%]
chandra_aca/tests/test_transform.py .............................                                [100%]

========================================= 270 passed in 48.68s =========================================
```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-latest) jeanconn-kady> git rev-parse HEAD
e633108f255de07bed3fff62e710a23ccc1b5556
(ska3-latest) jeanconn-kady> pytest
============================================= test session starts ==============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.1
collected 270 items                                                                                            

chandra_aca/tests/test_aca_image.py .......................                                              [  8%]
chandra_aca/tests/test_attitude.py .............................................................         [ 31%]
chandra_aca/tests/test_dark_model.py ............                                                        [ 35%]
chandra_aca/tests/test_dark_subtract.py .........                                                        [ 38%]
chandra_aca/tests/test_drift.py ..............................................                           [ 55%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                       [ 58%]
chandra_aca/tests/test_maude_decom.py .........................                                          [ 67%]
chandra_aca/tests/test_planets.py .................                                                      [ 74%]
chandra_aca/tests/test_psf.py ...                                                                        [ 75%]
chandra_aca/tests/test_residuals.py .....                                                                [ 77%]
chandra_aca/tests/test_star_probs.py .................................                                   [ 89%]
chandra_aca/tests/test_transform.py .............................                                        [100%]

======================================== 270 passed in 75.81s (0:01:15)
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
