### PR TITLE
make chandra_aca.drift.get_fid_offset faster

### DIFF
--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -150,8 +150,13 @@ class AcaDriftModel(object):
         if times.shape != t_ccd_degF.shape:
             raise ValueError("times and t_ccd args must match in shape")
 
-        if np.any(np.diff(times) < 0):
-            raise ValueError("times arg must be monotonically increasing")
+        # sort the times and t_ccd arrays so that the jumps can be applied in order.
+        if np.all(np.diff(times) >= 0):
+            idx = ...
+        else:
+            idx = np.argsort(times)
+        times = times[idx]
+        t_ccd_degF = t_ccd_degF[idx]
 
         if times[0] < CxoTime("2012:001:12:00:00").secs:
             raise ValueError("model is not applicable before 2012")
@@ -166,6 +171,8 @@ class AcaDriftModel(object):
         for jump_date, jump in self.jumps:
             jump_idx = np.searchsorted(times, CxoTime(jump_date).secs)
             out[jump_idx:] += jump
+
+        out[idx] = out  # Put back in original order
 
         return out[0] if is_scalar else out
 

--- a/chandra_aca/drift.py
+++ b/chandra_aca/drift.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 from astropy.utils.data import download_file
-from Chandra.Time import DateTime
 from cxotime import CxoTime, CxoTimeLike
 from ska_helpers import chandra_models
 from ska_helpers.utils import LazyDict
@@ -145,7 +144,7 @@ class AcaDriftModel(object):
 
         times, t_ccd_degF = np.broadcast_arrays(times, t_ccd_degF)
         is_scalar = times.ndim == 0 and t_ccd_degF.ndim == 0
-        times = DateTime(np.atleast_1d(times)).secs
+        times = CxoTime(np.atleast_1d(times)).secs
         t_ccd_degF = np.atleast_1d(t_ccd_degF)
 
         if times.shape != t_ccd_degF.shape:
@@ -154,18 +153,18 @@ class AcaDriftModel(object):
         if np.any(np.diff(times) < 0):
             raise ValueError("times arg must be monotonically increasing")
 
-        if times[0] < DateTime("2012:001:12:00:00").secs:
+        if times[0] < CxoTime("2012:001:12:00:00").secs:
             raise ValueError("model is not applicable before 2012")
 
         # Years from model `year0`
-        dyears = DateTime(times, format="secs").frac_year - self.year0
+        dyears = CxoTime(times, format="secs").frac_year - self.year0
 
         # Raw offsets without jumps
         out = (t_ccd_degF - self.offset) * self.scale + dyears * self.trend
 
         # Put in the step function jumps
         for jump_date, jump in self.jumps:
-            jump_idx = np.searchsorted(times, DateTime(jump_date).secs)
+            jump_idx = np.searchsorted(times, CxoTime(jump_date).secs)
             out[jump_idx:] += jump
 
         return out[0] if is_scalar else out
@@ -364,7 +363,7 @@ def get_target_aimpoint(date, cycle, detector, too=False, zero_offset_table=None
     if zero_offset_table is None:
         zero_offset_table = get_default_zero_offset_table()
     zero_offset_table.sort(["date_effective", "cycle_effective"])
-    date = DateTime(date).iso[:10]
+    date = CxoTime(date).iso[:10]
     # Entries for this detector before the 'date' given
     ok = (zero_offset_table["detector"] == detector) & (
         zero_offset_table["date_effective"] <= date

--- a/chandra_aca/tests/test_drift.py
+++ b/chandra_aca/tests/test_drift.py
@@ -146,6 +146,22 @@ def test_fid_offset_array(t, t_ccd, expected_dy, expected_dz):
     assert np.allclose(dz, expected_dz, atol=0.01)
 
 
+def test_fid_offset_array_sorted():
+    """
+    Test that the get_fid_offset function returns expected values when given
+    arrays of inputs.
+    """
+    t, t_ccd, expected_dy, expected_dz = (
+        np.array(["2018:284", "2022:293", "2018:286", "2022:295"]),
+        np.array([-14.0, -5.0, -18.0, 0]),
+        [7.96, -9.85, 35.92, -21.2],
+        [1.92, -7.65, 15.21, -15.16],
+    )
+    dy, dz = drift.get_fid_offset(t, t_ccd)
+    assert np.allclose(dy, expected_dy, atol=0.01)
+    assert np.allclose(dz, expected_dz, atol=0.01)
+
+
 @pytest.mark.parametrize(
     "t, t_ccd, expected_dy, expected_dz",
     [


### PR DESCRIPTION
## Description

This PR makes `chandra_aca.drift.get_fid_offset` faster by making `chandra_aca.drift.AcaDriftModel.calc` faster. The improvement comes from replacing `Chandra.DateTime` with `cxotime.CxoTime`.  After the changes in AcaDriftModel, I removed the last stray `DateTime` in this file (in `get_target_aimpoint`).

I also changed the algorithm so it accepts input times that are not sorted.

In my specific case, this brings down the time this function takes from 1m 57s to 2.7s.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows


```
(ska3-aca) ~/SAO/git/chandra_aca get_fid_offset $ git rev-parse HEAD
073b6047f8e40e5e3a8a8f0ff5e3d7e296a86584
(ska3-aca) ~/SAO/git/chandra_aca get_fid_offset $ pytest chandra_aca
============================================================== test session starts ===============================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 274 items                                                                                                                              

chandra_aca/tests/test_aca_image.py .......................                                                                                [  8%]
chandra_aca/tests/test_attitude.py .............................................................                                           [ 30%]
chandra_aca/tests/test_dark_model.py ............                                                                                          [ 35%]
chandra_aca/tests/test_dark_subtract.py .........                                                                                          [ 38%]
chandra_aca/tests/test_drift.py ...............................................                                                            [ 55%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                                                         [ 58%]
chandra_aca/tests/test_maude_decom.py .........................                                                                            [ 67%]
chandra_aca/tests/test_planets.py ....................                                                                                     [ 74%]
chandra_aca/tests/test_psf.py ...                                                                                                          [ 75%]
chandra_aca/tests/test_residuals.py ss...                                                                                                  [ 77%]
chandra_aca/tests/test_star_probs.py .................................                                                                     [ 89%]
chandra_aca/tests/test_transform.py .............................                                                                          [100%]

======================================================== 272 passed, 2 skipped in 44.06s =========================================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
