### PR TITLE
Support cheta as a source for get_aca_images

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -914,20 +914,25 @@ def get_aca_images_cheta(
     requested slot (``aca{slot}_*``), removes rows flagged bad in any fetched MSID for a
     slot, and returns a single table with one row per slot and readout.
 
-    Available MSIDs for selection with the ``msids`` option are:
+    Available MSIDs for selection with the ``msids`` option are::
 
-    - BGDAVG, BGDRMS, BGDSTAT, BGDTYP
-    - COMMCNT, COMMPROG, GLBSTAT
-    - HD3TLM62, HD3TLM63, HD3TLM64, HD3TLM65, HD3TLM66, HD3TLM67
-    - HD3TLM72, HD3TLM73, HD3TLM74, HD3TLM75, HD3TLM76, HD3TLM77
-    - IMGCOL0, IMGFID, IMGFUNC, IMGNUM, IMGROW0, IMGSCALE, IMGSTAT, IMGTLM
-    - INTEG, MJF, MNF, PIXTLM
-    - TEMPCCD, TEMPHOUS, TEMPPRIM, TEMPSEC (degC)
+      BGDAVG, BGDRMS, BGDSTAT, BGDTYP
+      COMMCNT, COMMPROG, GLBSTAT
+      HD3TLM62, HD3TLM63, HD3TLM64, HD3TLM65, HD3TLM66, HD3TLM67
+      HD3TLM72, HD3TLM73, HD3TLM74, HD3TLM75, HD3TLM76, HD3TLM77
+      IMGCOL0, IMGFID, IMGFUNC, IMGNUM, IMGROW0, IMGSCALE, IMGSTAT, IMGTLM (8x8)
+      INTEG, MJF, MNF, PIXTLM
+      TEMPCCD, TEMPHOUS, TEMPPRIM, TEMPSEC
 
     Notes:
 
-    - ``IMGTLM`` is 8x8 images as telemetered 10-bit unsigned integers.
+    - ``IMGTLM`` is 8x8 images as telemetered 10-bit unsigned integers. By default with
+      ``scale_img=True``, the output table will instead include a column ``IMG`` with
+      the scaled image in DN, computed as ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0``.
     - ``IMGNUM`` is always included in output table to identify slot for each row.
+    - If ``IMGTLM`` is requested then ``IMGSCALE`` is included in the output table.
+    - Providing ``msids="IMG*"`` will fetch all the image telemetry and is about twice
+      as fast as the default fetching all MSIDs.
 
     Parameters
     ----------
@@ -943,7 +948,7 @@ def get_aca_images_cheta(
         If `True`, sort the output by (time, slot). This can be time consuming so the
         default ordering is by (slot, time).
     scale_img : bool, default `True`
-        If `True`, return an ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` column in DN
+        If `True`, return a column ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` in DN
         instead of the raw 10-bit ``IMGTLM`` column.
     native_cheta_columns : bool, default `False`
         If `True`, return the native cheta MSID column names matching those in the the
@@ -970,9 +975,11 @@ def get_aca_images_cheta(
 
     out_msids = _expand_cheta_aca_images_msids(msids)
 
+    # Always need slot identification
     if "IMGNUM" not in out_msids:
         out_msids.append("IMGNUM")
-    if scale_img and "IMGSCALE" not in out_msids and "IMGTLM" in out_msids:
+    # Always want IMGSCALE if asking for IMGTLM (even if not scaling it is good to have)
+    if "IMGSCALE" not in out_msids and "IMGTLM" in out_msids:
         out_msids.append("IMGSCALE")
 
     # List of tables of ACA image telemetry from cheta
@@ -1037,7 +1044,7 @@ def _get_cheta_slot(start, stop, scale_img, fetch_func, out_msids, slot):
         dat = dat[~tbl_cols["bads"]]
     del dat["bads"]
 
-    if scale_img:
+    if scale_img and "IMGTLM" in out_msids:
         # Scale image data. Parentheses (imgscale / 32.0) are important since
         # IMGTLM * IMGSCALE / 32.0 will overflow the 16-bit unsigned int.
         imgs_dn = dat["IMGTLM"] * (dat["IMGSCALE"][:, None, None] / 32.0) - 50.0
@@ -1175,34 +1182,33 @@ def get_aca_images(
     start: CxoTimeLike, stop: CxoTimeLike, bgsub=False, source="maude", **kwargs
 ) -> apt.Table:
     """
-    Get ACA images and ancillary data from either the MAUDE or CXC data sources.
+    Get ACA image telemetry from the specified ``source``.
 
-    The returned table of ACA images and ancillary data will include the default columns
-    returned by chandra_aca.maude_decom.get_aca_images or
-    mica.archive.aca_l0.get_aca_images. Additionally, an IMGSIZE column will be added to
-    the maude_decom aca_images so images from either source will have that column::
+    By default the returned table of ACA image telemetry will include these columns::
 
-             name            dtype  unit
-      --------------------- ------- -----------
-         IMGSIZE              int32  pixels
+      TIME (mid-integration, cxcsec), INTEG (sec), END_INTEG_TIME (cxcsec)
+      MJF, MNF, VCDUCTR, IMG_VCDUCTR
+      AAPIXTLM, AABGDTYP
+      BGDAVG (DN), BGDRMS (DN), BGDSTAT
+      COMMCNT, COMMCNT_CHECKSUM_FAIL, COMMCNT_SYNTAX_ERROR
+      COMMPROG, COMMPROG_REPEAT, COMM_CHECKSUM_FAIL
+      GLBSTAT, SYNTAX_ERROR, RESET, CAL_FAIL, POWER_FAIL, ROM_FAIL, RAM_FAIL
+      IMG (8x8 DN), IMGFID, IMGFUNC, IMGNUM, IMGSCALE, IMGSIZE, IMGTYPE, IMGSTAT
+      IMGCOL0, IMGROW0, IMGROW_A1, IMGCOL_A1, IMGROW0_8X8, IMGCOL0_8X8
+      HIGH_BGD, ION_RAD, MULTI_STAR, COMMON_COL, QUAD_BOUND, DEF_PIXEL, SAT_PIXEL
+      TEMPCCD (K), TEMPHOUS (K), TEMPPRIM (K), TEMPSEC (K)
+      HD3TLM62, HD3TLM63, HD3TLM64, HD3TLM65, HD3TLM66, HD3TLM67
+      HD3TLM72, HD3TLM73, HD3TLM74, HD3TLM75, HD3TLM76, HD3TLM77
 
-    If bgsub is True then the table will also include columns::
+    If ``bgsub`` is `True` then the table will also include float columns::
 
-             name            dtype  unit
-      --------------------- ------- -----------
-         IMG_BGSUB          float64  DN
-         IMG_DARK           float64  DN
-         T_CCD_SMOOTH       float64  degC
+      IMG_BGSUB (DN) : background subtracted image
+      IMG_DARK (DN) : dark current image
+      T_CCD_SMOOTH (degC) : smoothed CCD temperature
 
-    where:
-
-    - 'IMG_BGSUB': background subtracted image
-    - 'IMG_DARK': dark current image
-    - 'T_CCD_SMOOTH': smoothed CCD temperature
-
-    The IMG_DARK individual values are only calculated if within the 1024x1024 dark
-    current map, otherwise they are set to 0.  In practice this is not an issue in that
-    IMG and IMG_BGSUB must be within the CCD to be tracked.
+    With ``source="cheta"``, the ``msids`` keyword can be used to select a subset of the
+    available ACA image telemetry MSIDs and the ``unit_system`` keyword can select the
+    unit of the temperatures.  See :func:`get_aca_images_cheta` for details.
 
     Parameters
     ----------
@@ -1244,8 +1250,9 @@ def get_aca_images(
         get_aca_images_func = mica.archive.aca_l0.get_aca_images
     elif source == "cheta":
         get_aca_images_func = get_aca_images_cheta
-        # Force option for cheta to match the API of the other sources.
-        kwargs["native_cheta_columns"] = False
+        # Set options for cheta to match the API of the other sources.
+        kwargs["native_cheta_columns"] = False  # always required
+        kwargs.setdefault("unit_system", "cxc")  # default can be changed
     else:
         raise ValueError(f"source must be 'maude', 'cxc', or 'cheta', not {source}")
 

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -5,11 +5,13 @@ Classes and utilities related to ACA readout images.
 See :ref:`aca_image` for more details and examples.
 """
 
+import fnmatch
 import os
 from copy import deepcopy
 from itertools import chain, count
 from math import floor
 from pathlib import Path
+from typing import Sequence
 
 import astropy.table as apt
 import numba
@@ -857,18 +859,329 @@ class AcaPsfLibrary(object):
         return out
 
 
+ACA_CHETA_MSIDS = [
+    "BGDAVG",
+    "BGDRMS",
+    "BGDSTAT",
+    "BGDTYP",
+    "COMMCNT",
+    "COMMPROG",
+    "GLBSTAT",
+    "HD3TLM62",
+    "HD3TLM63",
+    "HD3TLM64",
+    "HD3TLM65",
+    "HD3TLM66",
+    "HD3TLM67",
+    "HD3TLM72",
+    "HD3TLM73",
+    "HD3TLM74",
+    "HD3TLM75",
+    "HD3TLM76",
+    "HD3TLM77",
+    "IMGCOL0",
+    "IMGFID",
+    "IMGFUNC",
+    "IMGNUM",
+    "IMGROW0",
+    "IMGSCALE",
+    "IMGSTAT",
+    "IMGTLM",
+    "INTEG",
+    "MJF",
+    "MNF",
+    "PIXTLM",
+    "TEMPCCD",
+    "TEMPHOUS",
+    "TEMPPRIM",
+    "TEMPSEC",
+]
+
+
+def get_aca_images_cheta(
+    start: CxoTimeLike,
+    stop: CxoTimeLike,
+    msids=None,
+    slots=(0, 1, 2, 3, 4, 5, 6, 7),
+    sort=False,
+    scale_img=True,
+    native_cheta_columns=False,
+    unit_system="sci",
+) -> apt.Table:
+    """Get ACA image telemetry from cheta for selected ACA slots.
+
+    This fetches telemetry for the requested ACA image MSIDs from cheta for each
+    requested slot (``aca{slot}_*``), removes rows flagged bad in any fetched MSID for a
+    slot, and returns a single table with one row per slot and readout.
+
+    Available MSIDs for selection with the ``msids`` option are:
+
+    - BGDAVG, BGDRMS, BGDSTAT, BGDTYP
+    - COMMCNT, COMMPROG, GLBSTAT
+    - HD3TLM62, HD3TLM63, HD3TLM64, HD3TLM65, HD3TLM66, HD3TLM67
+    - HD3TLM72, HD3TLM73, HD3TLM74, HD3TLM75, HD3TLM76, HD3TLM77
+    - IMGCOL0, IMGFID, IMGFUNC, IMGNUM, IMGROW0, IMGSCALE, IMGSTAT, IMGTLM
+    - INTEG, MJF, MNF, PIXTLM
+    - TEMPCCD, TEMPHOUS, TEMPPRIM, TEMPSEC (degC)
+
+    Notes:
+
+    - ``IMGTLM`` is 8x8 images as telemetered 10-bit unsigned integers.
+    - ``IMGNUM`` is always included in output table to identify slot for each row.
+
+    Parameters
+    ----------
+    start, stop
+        Time range passed to ``cheta.fetch_sci.MSID``.
+    msids : None, str, or sequence of str
+        Requested ACA image telemetry MSIDs or glob patterns (for example,
+        ``"HD3TLM*"``). If `None`, all entries in ``ACA_CHETA_MSIDS`` are used. Default
+        is ``"IMG*"`` to fetch the image telemetry and related columns.
+    slots : Sequence of int, default ``(0, 1, 2, 3, 4, 5, 6, 7)``
+        ACA image slots to fetch.
+    sort : bool, default `False`
+        If `True`, sort the output by (time, slot). This can be time consuming so the
+        default ordering is by (slot, time).
+    scale_img : bool, default `True`
+        If `True`, return an ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` column in DN
+        instead of the raw 10-bit ``IMGTLM`` column.
+    native_cheta_columns : bool, default `False`
+        If `True`, return the native cheta MSID column names matching those in the the
+        ``msids`` selection list. By default, apply name munging and add bit status
+        columns to match the API of :func:`chandra_aca.aca_images.get_aca_images`.
+    unit_system : {"sci", "eng", "cxc"}, default "sci"
+        Fetch data using the unit system. This only impacts temperatures, which will be
+        in degC for "sci", K for "cxc" and degF for "eng".
+
+    Returns
+    -------
+    astropy.table.Table
+        ACA image telemetry for the requested slots and MSIDs.
+    """
+
+    from cheta import fetch, fetch_eng, fetch_sci
+
+    # Support setting the unit system via the different fetch modules
+    fetch_funcs = {"sci": fetch_sci, "eng": fetch_eng, "cxc": fetch}
+    if (fetch_func := fetch_funcs.get(unit_system)) is None:
+        raise ValueError(
+            f"unit_system must be one of ['sci', 'eng', 'cxc'], got {unit_system!r}"
+        )
+
+    out_msids = _expand_cheta_aca_images_msids(msids)
+
+    if "IMGNUM" not in out_msids:
+        out_msids.append("IMGNUM")
+    if scale_img and "IMGSCALE" not in out_msids and "IMGTLM" in out_msids:
+        out_msids.append("IMGSCALE")
+
+    # List of tables of ACA image telemetry from cheta
+    dats = [
+        _get_cheta_slot(start, stop, scale_img, fetch_func, out_msids, slot)
+        for slot in slots
+    ]
+
+    out = apt.vstack(dats)
+    if sort:
+        out.sort(["TIME", "IMGNUM"])
+    if not native_cheta_columns:
+        _munge_cheta_aca_images(out)
+
+    return out
+
+
+def _get_cheta_slot(start, stop, scale_img, fetch_func, out_msids, slot):
+    """Fetch and assemble cheta ACA telemetry for a single slot.
+
+    For each requested MSID, this fetches ``aca{slot}_{MSID}`` over the given
+    time interval, combines values into one table, and removes rows flagged bad
+    by any fetched MSID.
+
+    If ``scale_img`` is True, image telemetry is converted from raw ``IMGTLM``
+    values to DN via ``IMGTLM * (IMGSCALE / 32.0) - 50.0`` and the column is
+    renamed to ``IMG``.
+
+    Parameters
+    ----------
+    start, stop
+        Start and stop times passed to ``fetch_func.MSID``.
+    scale_img : bool
+        If True, scale image telemetry from ``IMGTLM`` to ``IMG`` in DN.
+    fetch_func
+        cheta fetch module (for example ``cheta.fetch_sci``) that provides
+        an ``MSID`` fetch API.
+    out_msids : sequence of str
+        MSIDs to fetch for this slot.
+    slot : int
+        ACA slot number.
+
+    Returns
+    -------
+    astropy.table.Table
+        Slot telemetry table with bad rows removed.
+    """
+    tbl_cols = {}
+    for msid in out_msids:
+        msid_slot = f"aca{slot}_" + msid
+        dat = fetch_func.MSID(msid_slot, start=start, stop=stop)
+        if "TIME" not in tbl_cols:
+            tbl_cols["TIME"] = dat.times
+        if "bads" not in tbl_cols:
+            tbl_cols["bads"] = dat.bads
+        else:
+            tbl_cols["bads"] |= dat.bads
+        tbl_cols[msid] = dat.vals
+
+    dat = apt.Table(tbl_cols)
+    if np.any(tbl_cols["bads"]):
+        dat = dat[~tbl_cols["bads"]]
+    del dat["bads"]
+
+    if scale_img:
+        # Scale image data. Parentheses (imgscale / 32.0) are important since
+        # IMGTLM * IMGSCALE / 32.0 will overflow the 16-bit unsigned int.
+        imgs_dn = dat["IMGTLM"] * (dat["IMGSCALE"][:, None, None] / 32.0) - 50.0
+        # Replace then rename column to preserve column ordering
+        dat["IMGTLM"] = imgs_dn.astype(np.float32)
+        dat.rename_column("IMGTLM", "IMG")
+
+    return dat
+
+
+def _expand_cheta_aca_images_msids(msids: None | str | Sequence[str]) -> list[str]:
+    """Expand and validate cheta ACA image telemetry MSID selections.
+
+    Parameters
+    ----------
+    msids : None, str, or sequence of str
+        MSID names or shell-style glob patterns matched against
+        ``ACA_CHETA_MSIDS``. If ``None``, use all available ACA image MSIDs.
+
+    Returns
+    -------
+    list of str
+        Expanded MSID list.
+
+    Raises
+    ------
+    ValueError
+        If any requested MSID pattern does not match known ACA image MSIDs.
+    """
+    if msids is None:
+        return ACA_CHETA_MSIDS
+
+    if isinstance(msids, str):
+        msids = [msids]
+
+    # Assemble list of matches from ACA_CHETA_MSIDS using file globbing
+    out_msids = []
+    for msid in msids:
+        matches = fnmatch.filter(ACA_CHETA_MSIDS, msid.upper())
+        if not matches:
+            raise ValueError(
+                f"msid {msid!r} does not match any known ACA image telemetry MSIDs"
+            )
+        out_msids.extend(matches)
+
+    return out_msids
+
+
+def _munge_cheta_aca_images(imgs: apt.Table) -> None:
+    """Normalize cheta ACA image columns to the standard get_aca_images schema.
+
+    This mutates ``imgs`` in place so that tables fetched from cheta match the column
+    naming and decoded-bit conventions returned by
+    :func:`mica.archive.aca_l0.get_aca_images`. The code is adapted from that function,
+    which in turn is matching the API of :func:`chandra_aca.maude_decom.get_aca_images`.
+
+    The function adds derived columns such as ``IMGSIZE``, ``IMGTYPE``,
+    ``END_INTEG_TIME``, ``IMGROW_A1``/``IMGCOL_A1``, ``IMGROW0_8X8``/ ``IMGCOL0_8X8``,
+    and VCDU counters. It also renames selected columns (for example ``BGDTYP`` ->
+    ``AABGDTYP`` and ``PIXTLM`` -> ``AAPIXTLM``) and expands packed status/telemetry
+    bytes into boolean or integer fields.
+
+    Parameters
+    ----------
+    imgs
+        ACA image telemetry table from cheta. The table is modified in place.
+
+    Returns
+    -------
+    None
+        The input table is updated in-place.
+    """
+    from mica.archive.aca_l0 import GLBSTAT_NAMES, IMGSTAT_NAMES, _extract_bits_as_uint8
+
+    def has(colname):
+        return colname in imgs.colnames
+
+    # Rename and rejigger colums to match chandra_aca.maude_decum.get_aca_images
+    imgs["IMGSIZE"] = 8
+    if has("INTEG"):
+        imgs["END_INTEG_TIME"] = imgs["TIME"] + imgs["INTEG"] / 2
+
+    for rc in ["ROW", "COL"]:
+        # IMGROW/COL0 are row/col of lower/left of 4x4, 6x6, or 8x8 image
+        # Make these new columns:
+        # IMGROW/COL_A1: row/col of pixel A1 of 4x4, 6x6, or 8x8 image
+        # IMGROW/COL0_8x8: row/col of lower/left of 8x8 image with smaller img centered
+        if has(f"IMG{rc}0"):
+            imgs[f"IMG{rc}_A1"] = imgs[f"IMG{rc}0"]
+            imgs[f"IMG{rc}0_8X8"] = imgs[f"IMG{rc}0"]
+
+    imgs["IMGTYPE"] = np.full(shape=len(imgs), fill_value=4)  # 8x8
+
+    # imgs.rename_column("IMGRAW", "IMG")
+    if has("BGDTYP"):
+        imgs.rename_column("BGDTYP", "AABGDTYP")
+    if has("PIXTLM"):
+        imgs.rename_column("PIXTLM", "AAPIXTLM")
+
+    # maude_decom.get_aca_images() provides both VCDUCTR (VCDU for each sub-image) and
+    # IMG_VCDUCTR (VCDU of first sub-image). For combined images, these are identical.
+    if has("MJF") and has("MNF"):
+        imgs["VCDUCTR"] = imgs["MJF"] * 128 + imgs["MNF"]
+        imgs["IMG_VCDUCTR"] = imgs["VCDUCTR"]
+
+    # Split uint8 GLBSTAT and IMGSTAT into individual bits. The stat_bit_names are
+    # in MSB order so we need to reverse them below.
+    for stat_name, stat_bit_names in (
+        ("GLBSTAT", GLBSTAT_NAMES),
+        ("IMGSTAT", IMGSTAT_NAMES),
+    ):
+        if has(stat_name):
+            for bit, name in zip(range(8), reversed(stat_bit_names), strict=False):
+                imgs[name] = (imgs[stat_name] & (1 << bit)) > 0
+
+    if has("COMMCNT"):
+        # Extract fields from the mica L0 8-bit COMMCNT value which is really three MSIDs.
+        # We need to use .data attribute of MaskedColumn to get a numpy masked array. The
+        # unpackbits function fails on MaskedColumn because it looks for a _mask attribute.
+        bits = np.unpackbits(imgs["COMMCNT"].data).reshape(-1, 8)
+        bits_rev = bits[:, ::-1]  # MSB is on the right (index=7)
+        imgs["COMMCNT"] = _extract_bits_as_uint8(bits_rev, 2, 8)
+        imgs["COMMCNT_CHECKSUM_FAIL"] = bits_rev[:, 0] > 0
+        imgs["COMMCNT_SYNTAX_ERROR"] = bits_rev[:, 1] > 0
+
+    if has("COMMPROG"):
+        # Extract fields from the mica L0 8-bit COMMPROG value which is really two MSIDs
+        bits = np.unpackbits(imgs["COMMPROG"].data).reshape(-1, 8)
+        bits_rev = bits[:, ::-1]
+        imgs["COMMPROG"] = _extract_bits_as_uint8(bits_rev, 2, 8)
+        imgs["COMMPROG_REPEAT"] = _extract_bits_as_uint8(bits_rev, 0, 2)
+
+
 @retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_aca_images(
-    start: CxoTimeLike, stop: CxoTimeLike, bgsub=False, source="maude", **maude_kwargs
-) -> Table:
+    start: CxoTimeLike, stop: CxoTimeLike, bgsub=False, source="maude", **kwargs
+) -> apt.Table:
     """
     Get ACA images and ancillary data from either the MAUDE or CXC data sources.
 
-    The returned table of ACA images and ancillary data will include the default
-    columns returned by chandra_aca.maude_decom.get_aca_images or
-    mica.archive.aca_l0.get_aca_images. Additionally, an IMGSIZE column will be
-    added to the maude_decom aca_images so images from either source will have
-    that column::
+    The returned table of ACA images and ancillary data will include the default columns
+    returned by chandra_aca.maude_decom.get_aca_images or
+    mica.archive.aca_l0.get_aca_images. Additionally, an IMGSIZE column will be added to
+    the maude_decom aca_images so images from either source will have that column::
 
              name            dtype  unit
       --------------------- ------- -----------
@@ -878,9 +1191,8 @@ def get_aca_images(
 
              name            dtype  unit
       --------------------- ------- -----------
-         IMG_BGSUB          float64  DN
-         IMG_DARK           float64  DN
-         T_CCD_SMOOTH       float64  degC
+         IMG_BGSUB          float64  DN IMG_DARK           float64  DN T_CCD_SMOOTH
+         float64  degC
 
     where:
 
@@ -888,9 +1200,9 @@ def get_aca_images(
     - 'IMG_DARK': dark current image
     - 'T_CCD_SMOOTH': smoothed CCD temperature
 
-    The IMG_DARK individual values are only calculated if within the 1024x1024
-    dark current map, otherwise they are set to 0.  In practice this is not an
-    issue in that IMG and IMG_BGSUB must be within the CCD to be tracked.
+    The IMG_DARK individual values are only calculated if within the 1024x1024 dark
+    current map, otherwise they are set to 0.  In practice this is not an issue in that
+    IMG and IMG_BGSUB must be within the CCD to be tracked.
 
     Parameters
     ----------
@@ -901,11 +1213,13 @@ def get_aca_images(
     bgsub : bool
         Include background subtracted images in output table. Default is False.
     source : str
-        Data source for image and temperature telemetry ('maude' or 'cxc'). For 'cxc',
-        the image telemetry is from mica and temperature telemetry is from CXC L0 via
-        cheta.
-    **maude_kwargs
-        Additional kwargs for maude data source.
+        Data source for image and temperature telemetry ('maude','cxc', or 'cheta'). For
+        'cxc', the image telemetry is from mica and temperature telemetry is from CXC L0
+        via cheta.
+    **kwargs
+        Additional kwargs for source-specific image data retrieval functions. See: -
+        :func:`chandra_aca.maude_decom.get_aca_images` -
+        :func:`mica.archive.aca_l0.get_aca_images` - :func:`get_aca_images_cheta`
 
     Returns
     -------
@@ -923,13 +1237,15 @@ def get_aca_images(
         get_aca_images_func = chandra_aca.maude_decom.get_aca_images
     elif source == "cxc":
         get_aca_images_func = mica.archive.aca_l0.get_aca_images
-        # Explicitly set maude_kwargs to empty dict for cxc source
-        maude_kwargs = {}
+    elif source == "cheta":
+        get_aca_images_func = get_aca_images_cheta
+        # Force option for cheta to match the API of the other sources.
+        kwargs["native_cheta_columns"] = False
     else:
-        raise ValueError(f"source must be 'maude' or 'cxc', not {source}")
+        raise ValueError(f"source must be 'maude', 'cxc', or 'cheta', not {source}")
 
     # Get images
-    imgs_table = get_aca_images_func(start, stop, **maude_kwargs)
+    imgs_table = get_aca_images_func(start, stop, **kwargs)
 
     # Add an IMGSIZE column if not present (maude)
     # IMGTYPE 4 -> 8, 1 -> 6, 0 -> 4
@@ -954,7 +1270,7 @@ def get_aca_images(
         img_dark = dark_data["image"]
         tccd_dark = dark_data["ccd_temp"]
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(
-            imgs_table["TIME"], source=source, **maude_kwargs
+            imgs_table["TIME"], source=source, **kwargs
         )
         imgs_dark = chandra_aca.dark_subtract.get_dark_current_imgs(
             imgs_table, img_dark, tccd_dark, t_ccds

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -903,7 +903,7 @@ def get_aca_images_cheta(
     stop: CxoTimeLike,
     msids=None,
     slots=(0, 1, 2, 3, 4, 5, 6, 7),
-    sort=False,
+    sort_by_time=False,
     scale_img=True,
     native_cheta_columns=False,
     unit_system="sci",
@@ -939,7 +939,7 @@ def get_aca_images_cheta(
         is ``"IMG*"`` to fetch the image telemetry and related columns.
     slots : Sequence of int, default ``(0, 1, 2, 3, 4, 5, 6, 7)``
         ACA image slots to fetch.
-    sort : bool, default `False`
+    sort_by_time : bool, default `False`
         If `True`, sort the output by (time, slot). This can be time consuming so the
         default ordering is by (slot, time).
     scale_img : bool, default `True`
@@ -948,7 +948,7 @@ def get_aca_images_cheta(
     native_cheta_columns : bool, default `False`
         If `True`, return the native cheta MSID column names matching those in the the
         ``msids`` selection list. By default, apply name munging and add bit status
-        columns to match the API of :func:`chandra_aca.aca_images.get_aca_images`.
+        columns to match the API of :func:`get_aca_images`.
     unit_system : {"sci", "eng", "cxc"}, default "sci"
         Fetch data using the unit system. This only impacts temperatures, which will be
         in degC for "sci", K for "cxc" and degF for "eng".
@@ -982,7 +982,7 @@ def get_aca_images_cheta(
     ]
 
     out = apt.vstack(dats)
-    if sort:
+    if sort_by_time:
         out.sort(["TIME", "IMGNUM"])
     if not native_cheta_columns:
         _munge_cheta_aca_images(out)

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -903,7 +903,7 @@ def get_aca_images_cheta(
     stop: CxoTimeLike,
     msids=None,
     slots=(0, 1, 2, 3, 4, 5, 6, 7),
-    sort_by_time=False,
+    sort_by_time=True,
     scale_img=True,
     native_cheta_columns=False,
     unit_system="sci",
@@ -943,9 +943,9 @@ def get_aca_images_cheta(
         ``"HD3TLM*"``). If `None` (default), all entries in ``ACA_CHETA_MSIDS`` are used.
     slots : Sequence of int, default ``(0, 1, 2, 3, 4, 5, 6, 7)``
         ACA image slots to fetch.
-    sort_by_time : bool, default `False`
+    sort_by_time : bool, default `True`
         If `True`, sort the output by (time, slot). This is 5-10% slower than the
-        default (slot, time) ordering.
+        (slot, time) ordering which is native to the cheta data structure.
     scale_img : bool, default `True`
         If `True`, return a column ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` in DN
         instead of the raw 10-bit ``IMGTLM`` column.

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1287,7 +1287,7 @@ def get_aca_images(
         img_dark = dark_data["image"]
         tccd_dark = dark_data["ccd_temp"]
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(
-            imgs_table["TIME"], source=source, **kwargs
+            imgs_table["TIME"], source=source, channel=kwargs.get("channel")
         )
         imgs_dark = chandra_aca.dark_subtract.get_dark_current_imgs(
             imgs_table, img_dark, tccd_dark, t_ccds

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -859,7 +859,7 @@ class AcaPsfLibrary(object):
         return out
 
 
-ACA_CHETA_MSIDS = [
+ACA_CHETA_MSIDS = (
     "BGDAVG",
     "BGDRMS",
     "BGDSTAT",
@@ -895,7 +895,7 @@ ACA_CHETA_MSIDS = [
     "TEMPHOUS",
     "TEMPPRIM",
     "TEMPSEC",
-]
+)
 
 
 def get_aca_images_cheta(
@@ -1074,7 +1074,7 @@ def _expand_cheta_aca_images_msids(msids: None | str | Sequence[str]) -> list[st
         If any requested MSID pattern does not match known ACA image MSIDs.
     """
     if msids is None:
-        return ACA_CHETA_MSIDS
+        return list(ACA_CHETA_MSIDS)
 
     if isinstance(msids, str):
         msids = [msids]

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1095,7 +1095,7 @@ def _expand_cheta_aca_images_msids(msids: None | str | Sequence[str]) -> list[st
             )
         out_msids.extend(matches)
 
-    return out_msids
+    return list(dict.fromkeys(out_msids))
 
 
 def _munge_cheta_aca_images(imgs: apt.Table) -> None:

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -944,8 +944,8 @@ def get_aca_images_cheta(
     slots : Sequence of int, default ``(0, 1, 2, 3, 4, 5, 6, 7)``
         ACA image slots to fetch.
     sort_by_time : bool, default `False`
-        If `True`, sort the output by (time, slot). This can be time consuming so the
-        default ordering is by (slot, time).
+        If `True`, sort the output by (time, slot). This is 5-10% slower than the
+        default (slot, time) ordering.
     scale_img : bool, default `True`
         If `True`, return a column ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` in DN
         instead of the raw 10-bit ``IMGTLM`` column.

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -11,10 +11,10 @@ from itertools import chain, count
 from math import floor
 from pathlib import Path
 
+import astropy.table as apt
 import numba
 import numpy as np
 import requests
-from astropy.table import Table
 from cxotime import CxoTimeLike
 from ska_helpers import retry
 
@@ -740,7 +740,6 @@ class AcaPsfLibrary(object):
     """
 
     def __init__(self, filename=None):
-        from astropy.table import Table  # Table is a somewhat-heavy import
 
         psfs = {}
 
@@ -748,7 +747,7 @@ class AcaPsfLibrary(object):
             filename = os.path.join(
                 os.path.dirname(__file__), "data", "aca_psf_lib.dat"
             )
-        dat = Table.read(filename, format="ascii.basic", guess=False)
+        dat = apt.Table.read(filename, format="ascii.basic", guess=False)
         self.dat = dat
 
         # Sub-pixel grid spacing in pixels.  This assumes the sub-pixels are

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1133,10 +1133,10 @@ def _munge_cheta_aca_images(imgs: apt.Table) -> None:
         imgs["END_INTEG_TIME"] = imgs["TIME"] + imgs["INTEG"] / 2
 
     for rc in ["ROW", "COL"]:
-        # IMGROW/COL0 are row/col of lower/left of 4x4, 6x6, or 8x8 image
+        # IMGROW/COL0 are row/col of lower/left of 8x8 image
         # Make these new columns:
-        # IMGROW/COL_A1: row/col of pixel A1 of 4x4, 6x6, or 8x8 image
-        # IMGROW/COL0_8x8: row/col of lower/left of 8x8 image with smaller img centered
+        # IMGROW/COL_A1: row/col of pixel A1 of 8x8 image
+        # IMGROW/COL0_8x8: row/col of lower/left of 8x8 image
         if has(f"IMG{rc}0"):
             imgs[f"IMG{rc}_A1"] = imgs[f"IMG{rc}0"]
             imgs[f"IMG{rc}0_8X8"] = imgs[f"IMG{rc}0"]

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1143,7 +1143,6 @@ def _munge_cheta_aca_images(imgs: apt.Table) -> None:
 
     imgs["IMGTYPE"] = np.full(shape=len(imgs), fill_value=4)  # 8x8
 
-    # imgs.rename_column("IMGRAW", "IMG")
     if has("BGDTYP"):
         imgs.rename_column("BGDTYP", "AABGDTYP")
     if has("PIXTLM"):

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1121,7 +1121,7 @@ def _munge_cheta_aca_images(imgs: apt.Table) -> None:
     def has(colname):
         return colname in imgs.colnames
 
-    # Rename and rejigger colums to match chandra_aca.maude_decum.get_aca_images
+    # Rename and rejigger columns to match chandra_aca.maude_decom.get_aca_images
     imgs["IMGSIZE"] = 8
     if has("INTEG"):
         imgs["END_INTEG_TIME"] = imgs["TIME"] + imgs["INTEG"] / 2

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -989,7 +989,13 @@ def get_aca_images_cheta(
 
     out = apt.vstack(dats)
     if sort_by_time:
-        out.sort(["TIME", "IMGNUM"])
+        # Since the time stamps are always either identical or separated by > 1.0 sec,
+        # we can do a lexical sort on (TIME, IMGNUM) by nudging the time stamps by
+        # IMGNUM * 0.01 sec. The 64-bit float has sufficient precision to distinguish
+        # between the 0.01 sec differences. This about 30 times faster than
+        # `out.sort(["TIME", "IMGNUM"])`.
+        idxs = np.argsort(out["TIME"] + out["IMGNUM"] * 0.01)
+        out = out[idxs]
     if not native_cheta_columns:
         _munge_cheta_aca_images(out)
 

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1171,7 +1171,6 @@ def _munge_cheta_aca_images(imgs: apt.Table) -> None:
         imgs["COMMPROG_REPEAT"] = _extract_bits_as_uint8(bits_rev, 0, 2)
 
 
-@retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
 def get_aca_images(
     start: CxoTimeLike, stop: CxoTimeLike, bgsub=False, source="maude", **kwargs
 ) -> apt.Table:
@@ -1235,7 +1234,12 @@ def get_aca_images(
 
     # Set up configuration for maude or cxc
     if source == "maude":
-        get_aca_images_func = chandra_aca.maude_decom.get_aca_images
+        get_aca_images_func = retry.retry_func(
+            chandra_aca.maude_decom.get_aca_images,
+            exceptions=requests.exceptions.RequestException,
+            delay=5,
+            tries=3,
+        )
     elif source == "cxc":
         get_aca_images_func = mica.archive.aca_l0.get_aca_images
     elif source == "cheta":

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -1191,8 +1191,9 @@ def get_aca_images(
 
              name            dtype  unit
       --------------------- ------- -----------
-         IMG_BGSUB          float64  DN IMG_DARK           float64  DN T_CCD_SMOOTH
-         float64  degC
+         IMG_BGSUB          float64  DN
+         IMG_DARK           float64  DN
+         T_CCD_SMOOTH       float64  degC
 
     where:
 

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -940,8 +940,7 @@ def get_aca_images_cheta(
         Time range passed to ``cheta.fetch_sci.MSID``.
     msids : None, str, or sequence of str
         Requested ACA image telemetry MSIDs or glob patterns (for example,
-        ``"HD3TLM*"``). If `None`, all entries in ``ACA_CHETA_MSIDS`` are used. Default
-        is ``"IMG*"`` to fetch the image telemetry and related columns.
+        ``"HD3TLM*"``). If `None` (default), all entries in ``ACA_CHETA_MSIDS`` are used.
     slots : Sequence of int, default ``(0, 1, 2, 3, 4, 5, 6, 7)``
         ACA image slots to fetch.
     sort_by_time : bool, default `False`
@@ -951,7 +950,7 @@ def get_aca_images_cheta(
         If `True`, return a column ``IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`` in DN
         instead of the raw 10-bit ``IMGTLM`` column.
     native_cheta_columns : bool, default `False`
-        If `True`, return the native cheta MSID column names matching those in the the
+        If `True`, return the native cheta MSID column names matching those in the
         ``msids`` selection list. By default, apply name munging and add bit status
         columns to match the API of :func:`get_aca_images`.
     unit_system : {"sci", "eng", "cxc"}, default "sci"

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -31,7 +31,8 @@ def get_tccd_data(
     times: np.array (float)
         Sampling times for CCD temperature data (CXC seconds).
     source : str, optional
-        Source of CCD temperature data ('maude' (default) or 'cxc' for cheta archive).
+        Source of CCD temperature data ('maude' (default) or 'cxc' or 'cheta' for cheta
+        archive).
     median_window : int, optional
         Median filter window to remove outliers (default=3).
     smooth_window : int, optional
@@ -64,7 +65,7 @@ def get_tccd_data(
             data_source += f" channel='{channel}'"
         with fetch_sci.data_source(data_source):
             dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
-    elif source == "cxc":
+    elif source in ("cxc", "cheta"):
         with fetch_sci.data_source("cxc"):
             dat = fetch_sci.Msid("aacccdpt", fetch_start, fetch_stop)
     else:

--- a/chandra_aca/maude_decom.py
+++ b/chandra_aca/maude_decom.py
@@ -1208,10 +1208,10 @@ def get_aca_images(start: CxoTimeLike, stop: CxoTimeLike, **kwargs):
                       INTEG float64 s
                      BGDAVG  uint16 DN
                      BGDRMS  uint16 DN
-                    TEMPCCD float32 degC
-                   TEMPHOUS float32 degC
-                   TEMPPRIM float32 degC
-                    TEMPSEC float32 degC
+                    TEMPCCD float32 K
+                   TEMPHOUS float32 K
+                   TEMPPRIM float32 K
+                    TEMPSEC float32 K
                     BGDSTAT   uint8
                    HIGH_BGD    bool
                    RAM_FAIL    bool

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -608,8 +608,8 @@ def test_get_aca_images_cxc_and_maude():
 
     This checks that the dark images are reasonable and the answers match maude.
     """
-    tstart = "2012:270:02:44:00"
-    tstop = "2012:270:02:47:00"
+    tstart = "2025:270:02:44:00"
+    tstop = "2025:270:02:47:00"
 
     # Get CXC data and check that it looks reasonable
     img_table_cxc = chandra_aca.aca_image.get_aca_images(
@@ -621,6 +621,17 @@ def test_get_aca_images_cxc_and_maude():
         tstart, tstop, source="cxc", bgsub=True
     )
     images_check_range(tstart, tstop, img_table_cxc_bgsub, bgsub=True)
+
+    # Get cheta data and check that it looks reasonable
+    img_table_cheta = chandra_aca.aca_image.get_aca_images(
+        tstart, tstop, source="cheta", bgsub=False
+    )
+    images_check_range(tstart, tstop, img_table_cheta, bgsub=False)
+
+    img_table_cheta_bgsub = chandra_aca.aca_image.get_aca_images(
+        tstart, tstop, source="cheta", bgsub=True
+    )
+    images_check_range(tstart, tstop, img_table_cheta_bgsub, bgsub=True)
 
     # Get MAUDE data and check that it looks reasonable
     img_table_maude = chandra_aca.aca_image.get_aca_images(
@@ -640,16 +651,26 @@ def test_get_aca_images_cxc_and_maude():
     assert np.allclose(img_table_cxc["IMG"], img_table_cxc_bgsub["IMG"])
     assert np.allclose(img_table_cxc["TIME"], img_table_cxc_bgsub["TIME"])
 
+    # Check that the two cheta tables are the same in the key columns
+    assert np.allclose(img_table_cheta["IMG"], img_table_cheta_bgsub["IMG"])
+    assert np.allclose(img_table_cheta["TIME"], img_table_cheta_bgsub["TIME"])
+
     # Check that the tables are the same
     img_table_maude.sort(["TIME", "IMGNUM"])
     img_table_maude_bgsub.sort(["TIME", "IMGNUM"])
     img_table_cxc.sort(["TIME", "IMGNUM"])
     img_table_cxc_bgsub.sort(["TIME", "IMGNUM"])
+    img_table_cheta.sort(["TIME", "IMGNUM"])
+    img_table_cheta_bgsub.sort(["TIME", "IMGNUM"])
 
     assert np.allclose(img_table_maude["IMG"], img_table_cxc["IMG"])
     assert np.allclose(img_table_maude["TIME"], img_table_cxc["TIME"])
+    assert np.allclose(img_table_cheta["IMG"], img_table_cxc["IMG"])
+    assert np.allclose(img_table_cheta["TIME"], img_table_cxc["TIME"])
     assert np.allclose(img_table_maude_bgsub["IMG"], img_table_cxc_bgsub["IMG"])
     assert np.allclose(img_table_maude_bgsub["TIME"], img_table_cxc_bgsub["TIME"])
+    assert np.allclose(img_table_cheta_bgsub["IMG"], img_table_cxc_bgsub["IMG"])
+    assert np.allclose(img_table_cheta_bgsub["TIME"], img_table_cxc_bgsub["TIME"])
 
 
 def test_get_ccd_quadrant():

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -707,7 +707,7 @@ def test_get_aca_images_cheta_matches_cxc():
     [
         pytest.param(
             None,
-            ["TIME"] + chandra_aca.aca_image.ACA_CHETA_MSIDS,
+            ["TIME"] + list(chandra_aca.aca_image.ACA_CHETA_MSIDS),
             id="msids-none",
         ),
         pytest.param(

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -781,7 +781,7 @@ def test_get_aca_images_cheta_sort_by_time(sort_by_time, sort_keys):
 
     imgs_expected = imgs.copy()
     imgs_expected.sort(sort_keys)
-    for msid in ("IMGNUM", "TIME"):
+    for msid in ("IMGNUM", "TIME", "BGDAVG"):
         npt.assert_array_equal(imgs[msid], imgs_expected[msid])
 
 

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -774,7 +774,7 @@ def test_get_aca_images_cheta_slots_0_4_imgnum_values():
 def test_get_aca_images_cheta_sort_by_time(sort_by_time, sort_keys):
     start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
 
-    # Use image telemetry so default scale_img=True has required inputs.
+    # Use a scalar MSID to keep the test lightweight; sorting is independent of scale_img.
     imgs = chandra_aca.aca_image.get_aca_images_cheta(
         start, stop, sort_by_time=sort_by_time, msids="BGDAVG"
     )

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import astropy.units as u
 import mica.common
 import numpy as np
+import numpy.testing as npt
 import pytest
 from cxotime import CxoTime
 from mica.archive.aca_dark import get_dark_cal_props
@@ -681,3 +682,150 @@ def test_get_ccd_quadrant():
 def test_get_ccd_quadrant_fail():
     with pytest.raises(ValueError, match="pix_zero_loc"):
         get_ccd_quadrant(0, 0, pix_zero_loc="bad")
+
+
+def test_get_aca_images_cheta_matches_cxc():
+    start, stop = "2026:001:00:00:00", "2026:001:00:30:00"
+    imgs_cxc = chandra_aca.aca_image.get_aca_images(start, stop, source="cxc")
+    imgs_cxc = imgs_cxc[imgs_cxc["IMGSIZE"] == 8]
+    imgs_cheta = chandra_aca.aca_image.get_aca_images(
+        start, stop, source="cheta", sort_by_time=True
+    )
+    assert len(imgs_cheta) == 3512
+    assert sorted(imgs_cheta.colnames) == sorted(imgs_cxc.colnames)
+    for colname in imgs_cheta.colnames:
+        if colname == "END_INTEG_TIME":
+            npt.assert_allclose(
+                imgs_cheta[colname], imgs_cxc[colname], atol=1e-6, rtol=0
+            )
+        else:
+            npt.assert_array_equal(imgs_cheta[colname], imgs_cxc[colname])
+
+
+@pytest.mark.parametrize(
+    "msids, expected_colnames",
+    [
+        pytest.param(
+            None,
+            ["TIME"] + chandra_aca.aca_image.ACA_CHETA_MSIDS,
+            id="msids-none",
+        ),
+        pytest.param(
+            "IMG*",
+            [
+                "TIME",
+                "IMGCOL0",
+                "IMGFID",
+                "IMGFUNC",
+                "IMGNUM",
+                "IMGROW0",
+                "IMGSCALE",
+                "IMGSTAT",
+                "IMGTLM",
+            ],
+            id="msids-img-star",
+        ),
+        pytest.param(
+            ["img*", "tempccd"],
+            [
+                "TIME",
+                "IMGCOL0",
+                "IMGFID",
+                "IMGFUNC",
+                "IMGNUM",
+                "IMGROW0",
+                "IMGSCALE",
+                "IMGSTAT",
+                "IMGTLM",
+                "TEMPCCD",
+            ],
+            id="msids-img-star-plus-tempccd",
+        ),
+    ],
+)
+def test_get_aca_images_cheta_msids_column_names(msids, expected_colnames):
+    start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
+
+    imgs = chandra_aca.aca_image.get_aca_images_cheta(
+        start,
+        stop,
+        msids=msids,
+        scale_img=False,
+        native_cheta_columns=True,
+    )
+    assert imgs.colnames == expected_colnames
+
+
+def test_get_aca_images_cheta_slots_0_4_imgnum_values():
+    start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
+    imgs = chandra_aca.aca_image.get_aca_images_cheta(start, stop, slots=[0, 4])
+
+    assert len(imgs) > 0
+    assert np.all(np.isin(imgs["IMGNUM"], [0, 4]))
+
+
+@pytest.mark.parametrize(
+    "sort_by_time, sort_keys",
+    [
+        pytest.param(False, ["IMGNUM", "TIME"], id="sort-by-slot-then-time"),
+        pytest.param(True, ["TIME", "IMGNUM"], id="sort-by-time-then-slot"),
+    ],
+)
+def test_get_aca_images_cheta_sort_by_time(sort_by_time, sort_keys):
+    start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
+
+    # Use image telemetry so default scale_img=True has required inputs.
+    imgs = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, sort_by_time=sort_by_time, msids="BGDAVG"
+    )
+
+    imgs_expected = imgs.copy()
+    imgs_expected.sort(sort_keys)
+    for msid in ("IMGNUM", "TIME"):
+        npt.assert_array_equal(imgs[msid], imgs_expected[msid])
+
+
+def test_get_aca_images_cheta_scale_img():
+    start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
+
+    imgs_scaled = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, msids="IMGTLM", scale_img=True
+    )
+    imgs_raw = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, msids="IMGTLM", scale_img=False
+    )
+
+    assert "IMG" in imgs_scaled.colnames
+    assert "IMGTLM" not in imgs_scaled.colnames
+    assert "IMG" not in imgs_raw.colnames
+    assert "IMGTLM" in imgs_raw.colnames
+
+    # Dtype should be uint16, allowing for explicit byte-order variants.
+    assert imgs_raw["IMGTLM"].dtype.type is np.uint16
+
+    imgs_raw_scaled = (
+        imgs_raw["IMGTLM"] * (imgs_raw["IMGSCALE"][:, None, None] / 32.0) - 50.0
+    )
+    npt.assert_allclose(imgs_scaled["IMG"], imgs_raw_scaled, atol=1e-6, rtol=0)
+
+
+def test_get_aca_images_cheta_unit_system_temp_msids():
+    start, stop = "2026:001:00:00:00", "2026:001:00:01:00"
+
+    imgs_sci = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, msids="TEMP*", unit_system="sci"
+    )
+    imgs_cxc = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, msids="TEMP*", unit_system="cxc"
+    )
+    imgs_eng = chandra_aca.aca_image.get_aca_images_cheta(
+        start, stop, msids="TEMP*", unit_system="eng"
+    )
+
+    temp_cols = ["TEMPCCD", "TEMPHOUS", "TEMPPRIM", "TEMPSEC"]
+    for col in temp_cols:
+        # cxc is Kelvin, sci is Celsius, eng is Fahrenheit.
+        npt.assert_allclose(imgs_cxc[col], imgs_sci[col] + 273.15, atol=1e-3, rtol=0)
+        npt.assert_allclose(
+            imgs_eng[col], imgs_sci[col] * 9.0 / 5.0 + 32.0, atol=1e-3, rtol=0
+        )

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -850,3 +850,31 @@ def test_get_aca_images_cheta_unit_system_temp_msids():
         npt.assert_allclose(
             imgs_eng[col], imgs_sci[col] * 9.0 / 5.0 + 32.0, atol=1e-3, rtol=0
         )
+
+
+def test_cheta_expand_msids():
+    """Ensure expansion is unique and retains order"""
+    msids1 = chandra_aca.aca_image._expand_cheta_aca_images_msids(["imgstat", "img*"])
+    assert msids1 == [
+        "IMGSTAT",  # first
+        "IMGCOL0",
+        "IMGFID",
+        "IMGFUNC",
+        "IMGNUM",
+        "IMGROW0",
+        "IMGSCALE",
+        "IMGTLM",
+    ]
+    msids2 = chandra_aca.aca_image._expand_cheta_aca_images_msids(["img*", "imgstat"])
+    assert msids2 == [
+        "IMGCOL0",
+        "IMGFID",
+        "IMGFUNC",
+        "IMGNUM",
+        "IMGROW0",
+        "IMGSCALE",
+        "IMGSTAT",  # original order
+        "IMGTLM",
+    ]
+    msids3 = chandra_aca.aca_image._expand_cheta_aca_images_msids(["img*"])
+    assert msids3 == msids2


### PR DESCRIPTION
## Description

This PR adds support for using `cheta` as an image telemetry source in `chandra_aca.aca_image.get_aca_images`, and introduces a dedicated `get_aca_images_cheta()` API for direct access to cheta image telemetry.

The implementation is designed to preserve the existing `get_aca_images` user experience while exposing cheta-specific controls (MSID filtering, slot selection, sorting, scaling, and unit system).

## Requires
- https://github.com/sot/cheta/pull/291 + data setup as detailed the PR

### New cheta image retrieval interface

- Added `ACA_CHETA_MSIDS` as the canonical list of supported cheta ACA image MSIDs.
- Added `get_aca_images_cheta(start, stop, ...)` with options:
  - `msids`
  - `slots`
  - `sort_by_time`
  - `scale_img`
  - `native_cheta_columns`
  - `unit_system`
- Added helper functions:
  - `_expand_cheta_aca_images_msids()` to expand/validate requested MSIDs (including glob patterns).
  - `_get_cheta_slot()` to fetch one slot, combine requested MSIDs, remove bad rows, and apply optional image scaling.
  - `_munge_cheta_aca_images()` to map native cheta columns/bitfields into the standard schema used by `get_aca_images`.

### get_aca_images integration

- Added `source="cheta"` path in `get_aca_images()`.
- For `source="cheta"`, wrapper behavior aligns output with existing APIs:
  - `native_cheta_columns=False`
  - `unit_system="cxc"` default at wrapper level

### Behavior and compatibility details

- `IMGNUM` is always included in cheta output to retain slot identity.
- If `IMGTLM` is requested, `IMGSCALE` is automatically included.
- `scale_img=True` converts raw image telemetry to DN via `IMG = IMGTLM * (IMGSCALE / 32.0) - 50.0`
- Sorting behavior:
  - `sort_by_time=False` => sorted by `(IMGNUM, TIME)`
  - `sort_by_time=True` => sorted by `(TIME, IMGNUM)`
- `unit_system` supports `"sci"`, `"cxc"`, and `"eng"` for temperature MSIDs.

### Documentation cleanups

- Updated related docs/comments to reflect unit expectations (notably temperature unit consistency in `maude_decom` docs).
- Expanded/clarified new docstrings around cheta-specific APIs and behavior.

## Tests Added / Updated

Extended `chandra_aca/tests/test_aca_image.py` with targeted cheta coverage:

- cheta vs cxc regression/parity check for 8x8 images.
- `msids` behavior checks (`None`, glob patterns, and mixed requests).
- `slots` filter check (`slots=[0, 4]`) with `IMGNUM` validation.
- parametrized `sort_by_time` behavior check for expected ordering.
- `scale_img` behavior check:
  - `scale_img=False` returns `IMGTLM` with `np.uint16` payload
  - scaled raw values match `IMG` from `scale_img=True`
- `unit_system` conversion checks for `TEMP*` MSIDs across `sci`, `cxc`, and `eng` (absolute tolerance `1e-3`).

## Validation

Targeted tests were run in the `ska3-dev` conda environment, including the new cheta-focused tests for:

- `msids`
- `slots`
- `sort_by_time`
- `scale_img`
- `unit_system`

All targeted tests passed.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- Adds a new `source` option for `get_aca_images` and a new function `get_aca_images_cheta`.
- Previously calling `get_aca_images(start, stop, source="cxc", foo=1)` would silently drop any keyword arguments like `foo`. Now this gets passed into the lower-level mica `get_aca_images` and will fail. This "validation" of arguments is a good thing (i.e. additional keyword arguments should be applicable to the source).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-dev) ➜  chandra_aca git:(cheta-aca-images) git rev-parse --short HEAD                  
dacd00f
(ska3-dev) ➜  chandra_aca git:(cheta-aca-images) pytest
============================================== test session starts ===============================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0, doctestplus-1.7.1
collected 283 items                                                                                              

chandra_aca/tests/test_aca_image.py .................................                                      [ 11%]
chandra_aca/tests/test_attitude.py .............................................................           [ 33%]
chandra_aca/tests/test_dark_model.py ............                                                          [ 37%]
chandra_aca/tests/test_dark_subtract.py .........                                                          [ 40%]
chandra_aca/tests/test_drift.py ..............................................                             [ 56%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                         [ 59%]
chandra_aca/tests/test_maude_decom.py .........................                                            [ 68%]
chandra_aca/tests/test_planets.py ....................                                                     [ 75%]
chandra_aca/tests/test_psf.py ...                                                                          [ 76%]
chandra_aca/tests/test_residuals.py .....                                                                  [ 78%]
chandra_aca/tests/test_star_probs.py .................................                                     [ 89%]
chandra_aca/tests/test_transform.py .............................                                          [100%]

============================================== 283 passed in 51.87s ==============================================
```

Independent check of unit tests by Jean
- [x] OSX
```
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
dacd00f6e393fcad62b8b630c95a3b9a38737371
(ska3-latest) flame:chandra_aca jean$ env PYTHONPATH=/Users/jean/git/cheta pytest
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 283 items                                                                                                                                                                            

chandra_aca/tests/test_aca_image.py .................................                                                                                                                    [ 11%]
chandra_aca/tests/test_attitude.py .............................................................                                                                                         [ 33%]
chandra_aca/tests/test_dark_model.py ............                                                                                                                                        [ 37%]
chandra_aca/tests/test_dark_subtract.py .........                                                                                                                                        [ 40%]
chandra_aca/tests/test_drift.py ..............................................                                                                                                           [ 56%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                                                                                                       [ 59%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                                                          [ 68%]
chandra_aca/tests/test_planets.py ....................                                                                                                                                   [ 75%]
chandra_aca/tests/test_psf.py ...                                                                                                                                                        [ 76%]
chandra_aca/tests/test_residuals.py .....                                                                                                                                                [ 78%]
chandra_aca/tests/test_star_probs.py .................................                                                                                                                   [ 89%]
chandra_aca/tests/test_transform.py .............................                                                                                                                        [100%]

======================================================================================= warnings summary
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
