### PR TITLE
Fix bug clipping/flooring the background subtracted images at zero

### DIFF
--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -957,10 +957,12 @@ def get_aca_images(
         t_ccds = chandra_aca.dark_subtract.get_tccd_data(
             imgs_table["TIME"], source=source, **maude_kwargs
         )
-        imgs_dark = chandra_aca.dark_subtract.get_dark_current_imgs(
-            imgs_table, img_dark, tccd_dark, t_ccds
+        imgs_bgsub, imgs_dark = chandra_aca.dark_subtract.get_aca_images_bgd_sub(
+            img_table=imgs_table,
+            t_ccd_vals=t_ccds,
+            img_dark=img_dark,
+            tccd_dark=tccd_dark,
         )
-        imgs_bgsub = (imgs_table["IMG"] - imgs_dark).clip(0, None)
 
         imgs_table["IMG_BGSUB"] = imgs_bgsub
         imgs_table["IMG_DARK"] = imgs_dark

--- a/chandra_aca/aca_image.py
+++ b/chandra_aca/aca_image.py
@@ -960,8 +960,7 @@ def get_aca_images(
         imgs_dark = chandra_aca.dark_subtract.get_dark_current_imgs(
             imgs_table, img_dark, tccd_dark, t_ccds
         )
-        imgs_bgsub = imgs_table["IMG"] - imgs_dark
-        imgs_bgsub.clip(0, None)
+        imgs_bgsub = (imgs_table["IMG"] - imgs_dark).clip(0, None)
 
         imgs_table["IMG_BGSUB"] = imgs_bgsub
         imgs_table["IMG_DARK"] = imgs_dark

--- a/chandra_aca/dark_subtract.py
+++ b/chandra_aca/dark_subtract.py
@@ -110,8 +110,7 @@ def get_aca_images_bgd_sub(img_table, t_ccd_vals, img_dark, tccd_dark):
             Dark current images (DN).
     """
     imgs_dark = get_dark_current_imgs(img_table, img_dark, tccd_dark, t_ccd_vals)
-    imgs_bgsub = img_table["IMG"] - imgs_dark
-    imgs_bgsub.clip(0, None)
+    imgs_bgsub = (img_table["IMG"] - imgs_dark).clip(0, None)
 
     return imgs_bgsub, imgs_dark
 

--- a/chandra_aca/tests/test_aca_image.py
+++ b/chandra_aca/tests/test_aca_image.py
@@ -558,10 +558,11 @@ def images_check_range(start, stop, img_table, *, bgsub):
     # Check that all the slots are in there
     assert np.all(np.isin(np.arange(8), img_table["IMGNUM"]))
 
-    # Check that if the table has BGSUB column that IMG - DARK = BGSUB
+    # Check that if the table has BGSUB column that IMG - DARK = BGSUB, floored at 0
     if bgsub:
         assert np.allclose(
-            img_table["IMG"] - img_table["IMG_DARK"], img_table["IMG_BGSUB"]
+            np.clip(img_table["IMG"] - img_table["IMG_DARK"], 0, None),
+            img_table["IMG_BGSUB"],
         )
 
     # If there's a DARK column, then check it against the dark image from the dark cal

--- a/chandra_aca/tests/test_dark_subtract.py
+++ b/chandra_aca/tests/test_dark_subtract.py
@@ -152,8 +152,37 @@ def test_dcsub_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
     )
     assert imgs_bgsub.shape == (8, 8, 8)
     # Note that the mock unsubtracted data is originally 16 * 1.696 / 5
-    exp = 16 - dc_imgs_dn
+    # dc_imgs_dn exceeds 16 for some pixels, so the expected value must be
+    # floored at 0 to match the clipping applied by get_aca_images_bgd_sub.
+    assert np.any(dc_imgs_dn > 16)
+    exp = np.clip(16 - dc_imgs_dn, 0, None)
     assert np.allclose(imgs_bgsub * 5 / 1.696, exp, atol=1e-6, rtol=0)
+
+
+def test_get_aca_images_bgd_sub_floors_negative_values_at_zero():
+    """
+    Confirm that get_aca_images_bgd_sub floors negative background-subtracted
+    values at 0 instead of returning them unclipped.
+    """
+    img_table = Table()
+    img_table["TIME"] = np.arange(1)
+    img_table["IMGROW0_8X8"] = np.array([-512])
+    img_table["IMGCOL0_8X8"] = np.array([-512])
+    img_table["IMG"] = np.zeros((1, 8, 8))
+    img_table["IMGNUM"] = 0
+
+    # A dark current image much larger than the (zero) raw image guarantees
+    # IMG - IMG_DARK is negative everywhere.
+    img_dark = np.full((1024, 1024), fill_value=100.0)
+
+    imgs_bgsub, imgs_dark = get_aca_images_bgd_sub(
+        img_table=img_table,
+        img_dark=img_dark,
+        tccd_dark=-10,
+        t_ccd_vals=np.array([-10]),
+    )
+    assert np.all(imgs_dark > 0)
+    assert np.all(imgs_bgsub == 0)
 
 
 def test_get_tccd_data():
@@ -189,7 +218,7 @@ def test_get_aca_images(mock_dc, mock_img_table, dc_imgs_dn):
         t_ccd_vals=np.repeat(-10, 8),
     )
     assert imgs_bgsub.shape == (8, 8, 8)
-    exp = 16 - dc_imgs_dn
+    exp = np.clip(16 - dc_imgs_dn, 0, None)
     assert np.allclose(imgs_bgsub * 5 / 1.696, exp, atol=1e-6, rtol=0)
 
 


### PR DESCRIPTION
## Description

Fix classic bug clipping/flooring the background subtracted images at zero.

We intended to clip at zero - the code was not effectively doing that.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:chandra_aca jean$ git rev-parse HEAD
cf6a9fcc722ac086a8758394b955e10d051ee8cf
(ska3-latest) flame:chandra_aca jean$ pytest
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 274 items                                                                                                                                                                            

chandra_aca/tests/test_aca_image.py .......................                                                                                                                              [  8%]
chandra_aca/tests/test_attitude.py .............................................................                                                                                         [ 30%]
chandra_aca/tests/test_dark_model.py ............                                                                                                                                        [ 35%]
chandra_aca/tests/test_dark_subtract.py ..........                                                                                                                                       [ 38%]
chandra_aca/tests/test_drift.py ..............................................                                                                                                           [ 55%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                                                                                                       [ 58%]
chandra_aca/tests/test_maude_decom.py .........................                                                                                                                          [ 67%]
chandra_aca/tests/test_planets.py ....................                                                                                                                                   [ 74%]
chandra_aca/tests/test_psf.py ...                                                                                                                                                        [ 75%]
chandra_aca/tests/test_residuals.py .....                                                                                                                                                [ 77%]
chandra_aca/tests/test_star_probs.py .................................                                                                                                                   [ 89%]
chandra_aca/tests/test_transform.py .............................                                                                                                                        [100%]

======================================================================================= warnings summary
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
