### PR TITLE
Add min_samples argument to read_manvr_mon_images for sample filtering

### DIFF
--- a/chandra_aca/manvr_mon_images.py
+++ b/chandra_aca/manvr_mon_images.py
@@ -60,6 +60,7 @@ def read_manvr_mon_images(  # noqa: PLR0915
     filter_constraints: bool | dict = False,
     require_same_row_col: bool = True,
     exact_interval: bool = False,
+    min_samples: int = 1,
     data_dir: Path | str | None = None,
 ) -> apt.Table:
     """Read ACA maneuver monitor window images from archived data files.
@@ -93,6 +94,8 @@ def read_manvr_mon_images(  # noqa: PLR0915
         If True, only include images with times exactly within start and stop.
         Otherwise include all times within the maneuvers that are included within start
         and stop. Default is False.
+    min_samples : int, optional
+        Minimum number of samples required for each maneuver. Default is 1.
     data_dir : Path or str, optional
         Root directory containing the archived image files organized as
         ``data_dir/YYYY/DOY/*.npz``. Default is ``$SKA/data/manvr_mon_images``.
@@ -145,6 +148,8 @@ def read_manvr_mon_images(  # noqa: PLR0915
         for path in sorted(dir.glob("*.npz")):
             with np.load(path) as dat:
                 n_samp = len(dat["t_ccd"])
+                if n_samp < min_samples:
+                    continue
                 # Move the sample dimension (-1) to the front so they concat properly.
                 # Imgs will then be indexed as [sample, slot, row, col].
                 imgs_list.append(np.moveaxis(dat["slot_imgs"], -1, 0))


### PR DESCRIPTION
## Description

Add a `min_samples` argument to `read_manvr_mon_images` for sample filtering.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-dev) ➜  chandra_aca git:(read-manvr-mon-images-add-min-samples-arg) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0, doctestplus-1.7.1
collected 285 items                                                                                                                 

chandra_aca/tests/test_aca_image.py .................................                                                         [ 11%]
chandra_aca/tests/test_attitude.py .............................................................                              [ 32%]
chandra_aca/tests/test_dark_model.py ............                                                                             [ 37%]
chandra_aca/tests/test_dark_subtract.py ..........                                                                            [ 40%]
chandra_aca/tests/test_drift.py ...............................................                                               [ 57%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                                            [ 59%]
chandra_aca/tests/test_maude_decom.py .........................                                                               [ 68%]
chandra_aca/tests/test_planets.py ....................                                                                        [ 75%]
chandra_aca/tests/test_psf.py ...                                                                                             [ 76%]
chandra_aca/tests/test_residuals.py .....                                                                                     [ 78%]
chandra_aca/tests/test_star_probs.py .................................                                                        [ 89%]
chandra_aca/tests/test_transform.py .............................                                                             [100%]

======================================================= 285 passed in 43.37s ========================================================
```

Independent check of unit tests by Jean
- [x] [PLATFORM]:
```
(ska3-latest) flame:chandra_aca jean$ env PYTHONPATH=/Users/jean/git/cheta pytest
=================================================== test session starts ====================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 285 items                                                                                                        

chandra_aca/tests/test_aca_image.py .................................                                                [ 11%]
chandra_aca/tests/test_attitude.py .............................................................                     [ 32%]
chandra_aca/tests/test_dark_model.py ............                                                                    [ 37%]
chandra_aca/tests/test_dark_subtract.py ..........                                                                   [ 40%]
chandra_aca/tests/test_drift.py ...............................................                                      [ 57%]
chandra_aca/tests/test_manvr_mon_images.py .......                                                                   [ 59%]
chandra_aca/tests/test_maude_decom.py .........................                                                      [ 68%]
chandra_aca/tests/test_planets.py ....................                                                               [ 75%]
chandra_aca/tests/test_psf.py ...                                                                                    [ 76%]
chandra_aca/tests/test_residuals.py .....                                                                            [ 78%]
chandra_aca/tests/test_star_probs.py .................................                                               [ 89%]
chandra_aca/tests/test_transform.py .............................                                                    [100%]

===================================================== warnings summary
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Used in SamBa pixel values analysis notebooks.
